### PR TITLE
Upgrade psycopg2-binary to support Python v3.11

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(name="pipelinewise-target-redshift",
       install_requires=[
           'pipelinewise-singer-python==1.*',
           'boto3==1.26.*',
-          'psycopg2-binary==2.8.5',
+          'psycopg2-binary==2.9.7',
           'inflection==0.4.0',
           'joblib>=1.2.0',
           'urllib3>=1.26.5'


### PR DESCRIPTION
- Python 3.11 support is added in psycopg2-binary v2.9.5 and above.
  -  See: https://github.com/psycopg/psycopg2/blob/master/NEWS
- Therefore, we upgrade this dependency to the latest 2.9.x version.