### PR TITLE
[App Update][Replication] Full-refresh mechanism for Loader target-redshift [DATA-2261]

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Full list of options in `config.json`:
   python3 -m venv venv
   . venv/bin/activate
   pip install --upgrade pip
-  pip install .[test]
+  pip install -e ".[test]"
 ```
 
 1. To run unit tests:

--- a/target_redshift/db_sync.py
+++ b/target_redshift/db_sync.py
@@ -518,6 +518,7 @@ class DbSync:
                     inserts = cur.rowcount
 
                 elif self.full_refresh:
+                    self.logger.info("Performing full refresh")
                     archived_target_table = self.table_name(stream, is_stage=False, is_archived=True)
                     table_swap_sql = """BEGIN;
                         ALTER TABLE {} RENAME TO {};
@@ -531,9 +532,9 @@ class DbSync:
                         target_table,
                         self.drop_table_query(is_stage=False, is_archived=True)
                     )
-                    self.logger.debug("Running query: {}".format(table_swap_sql))
+                    self.logger.info("Running full-refresh query: {}".format(table_swap_sql))
                     cur.execute(table_swap_sql)
-                    
+
                 # Step 5/b: Insert only if no primary key
                 else:
                     insert_sql = """INSERT INTO {} ({})


### PR DESCRIPTION
https://kaligo.atlassian.net/browse/DATA-2261

# Background
As discussed in this [Thread](https://kaligo.slack.com/archives/C051J057K24/p1739846297774169), when we specify full-table replication for tap-postgres, we also expect that the source table in Redshift to be refreshed according to the changes in the source table.
But it seems like the current implementation of target-redshift is following UPSERT approach. It won’t delete the Redshift’s data that is already deleted at sources.
# Design

- On target-redshift side, we add another flag/attribute called full-refresh
- If `full-refresh` is turned on, it will perform the swapping mechanism:
```
Rename Target-table as Archived-Target-table
Rename Stg-table as Target-table
Drop table Target-table
```

# Impact

Now, we will have the flag to turn on the behavior for any tables that we want. 

# Caveats

We can't copy over the privileges in the Target Table to the STG Table if we are following this way. But as discussed in the [Thread](https://kaligo.slack.com/archives/C051J057K24/p1739846297774169),  for now we don't focus into this topic so will revisit this when the problem really matters. 

# Testing

- Firstly, config the new `target-redshift`:
<img width="863" alt="Screenshot 2025-02-18 at 18 27 02" src="https://github.com/user-attachments/assets/e9d2f53e-66e1-4eb3-ba2a-4afbab4809d6" />

- This is the `tap-postgres` that we going to replicate (`campaigns` will be full-loaded everytime we run `tap-postgres`)
<img width="492" alt="Screenshot 2025-02-18 at 18 28 18" src="https://github.com/user-attachments/assets/fcc33413-06dc-4232-8876-2548827de06c" />

- Then, we run `tap-postgres` and persist the state into the json file (for the ease of debugging)
<img width="925" alt="Screenshot 2025-02-18 at 18 30 40" src="https://github.com/user-attachments/assets/d0c9c9d4-1eed-4202-add8-4ad1f417b2d9" />

- Then, we run `target-redshift` with the state above
<img width="937" alt="Screenshot 2025-02-18 at 18 31 21" src="https://github.com/user-attachments/assets/17468ed4-57d9-482c-b209-8c1145f82886" />

# Docs

None