### PR TITLE
fix(cve): upgrade packages to fix Trivy CVE-2025-66471 checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,19 +10,18 @@ on:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
     strategy:
       fail-fast: true
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.9, 3.12]
 
     steps:
       - name: Checking out repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
-      - name: Set up Python ${{ matrix.container[1] }}
-        uses: actions/setup-python@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -37,7 +36,7 @@ jobs:
           pip install .[test]
 
       - name: Check if pylint is happy
-        run: pylint target_redshift -d C,W,unexpected-keyword-arg,duplicate-code
+        run: pylint target_redshift -d C,W,unexpected-keyword-arg --fail-under=9.5
 
       - name: Run Unit Tests
         run: pytest -v --disable-pytest-warnings tests/unit

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 # IDE
 .vscode
 .idea/*
-
+.python-version
 
 # Python
 __pycache__/
@@ -32,3 +32,4 @@ tmp
 # Docs
 docs/_build/
 docs/_templates/
+build/

--- a/setup.py
+++ b/setup.py
@@ -19,15 +19,16 @@ setup(name="pipelinewise-target-redshift",
       py_modules=["target_redshift"],
       install_requires=[
           'pipelinewise-singer-python==1.*',
-          'boto3==1.26.*',
-          'psycopg2-binary==2.9.10',
+          'boto3>=1.41.0',
+          'psycopg2-binary==2.9.11',
           'inflection==0.4.0',
-          'joblib>=1.2.0',
-          'urllib3>=1.26.5'
+          'joblib>=1.5.0',
+          'urllib3>=2.6.1,<3.0.0; python_version >= "3.10"',
+          'urllib3>=1.25.4,<1.27; python_version < "3.10"'
       ],
       extras_require={
           "test": [
-                "pylint==2.4.2",
+                "pylint>=2.17.0",
                 "pytest==6.2.5",
                 "mock==3.0.5",
                 "coverage==4.5.4"


### PR DESCRIPTION
Cherry-pick from https://github.com/Kaligo/pipelinewise-target-redshift/pull/5 to unblock[ DataOps CVE check failures](https://jenkins.int.kaligo.com/blue/organizations/jenkins/Ascenda%2Fdataops/detail/develop/12146/pipeline):
```
Python (python-pkg)

===================

Total: 2 (HIGH: 2, CRITICAL: 0)



┌────────────────────┬────────────────┬──────────┬────────┬───────────────────┬───────────────┬────────────────────────────────────────────────────────────┐

│      Library       │ Vulnerability  │ Severity │ Status │ Installed Version │ Fixed Version │                           Title                            │

├────────────────────┼────────────────┼──────────┼────────┼───────────────────┼───────────────┼────────────────────────────────────────────────────────────┤

│ urllib3 (METADATA) │ CVE-2025-66418 │ HIGH     │ fixed  │ 1.26.20           │ 2.6.0         │ urllib3 is a user-friendly HTTP client library for Python. │

│                    │                │          │        │                   │               │ Starting in ......                                         │

│                    │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2025-66418                 │

│                    ├────────────────┤          │        │                   │               ├────────────────────────────────────────────────────────────┤

│                    │ CVE-2025-66471 │          │        │                   │               │ urllib3 is a user-friendly HTTP client library for Python. │

│                    │                │          │        │                   │               │ Starting in ......                                         │

│                    │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2025-66471                 │

└────────────────────┴────────────────┴──────────┴────────┴───────────────────┴───────────────┴────────────────────────────────────────────────────────────┘


```