### PR TITLE
bump version to 1.6.3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md") as f:
 
 setup(
     name="pipelinewise-target-redshift",
-    version="1.6.1",
+    version="1.6.2",
     description="Singer.io target for loading data to Amazon Redshift - PipelineWise compatible",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md") as f:
 
 setup(
     name="pipelinewise-target-redshift",
-    version="1.6.2",
+    version="1.6.3",
     description="Singer.io target for loading data to Amazon Redshift - PipelineWise compatible",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
This PR is to bump a new version of target-redshift from 1.6.1 to 1.6.3