### PR TITLE
feat: Fast Sync Iceberg — Land fast sync data into Apache Iceberg

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install --upgrade pip setuptools wheel
-          pip install .[test]
+          pip install --pre .[test]
 
       - name: Check if pylint is happy
         run: pylint target_redshift -d C,W,unexpected-keyword-arg --fail-under=9.5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pip install --upgrade pip setuptools wheel
+          pip install --pre --upgrade pip setuptools wheel
           pip install --pre .[test]
 
       - name: Check if pylint is happy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: [3.9, 3.12]
+        python-version: [3.12]
 
     steps:
       - name: Checking out repo
@@ -32,8 +32,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pip install --pre --upgrade pip setuptools wheel
-          pip install --pre .[test]
+          pip install --upgrade pip setuptools wheel
+          pip install .[test]
 
       - name: Check if pylint is happy
         run: pylint target_redshift -d C,W,unexpected-keyword-arg --fail-under=9.5

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,5 @@ tmp
 docs/_build/
 docs/_templates/
 build/
+
+output.jsonl

--- a/README.md
+++ b/README.md
@@ -102,6 +102,9 @@ Full list of options in `config.json`:
 | append_only                         | Boolean |    No      | (Default: False) In fast sync mode, append all records from the stage table to the target table without performing updates or deletions. This is useful for immutable data like events where you only want to append new records. When enabled, all records from the stage table are inserted into the target table regardless of whether they already exist.
 | detect_deletions                    | Boolean |    No      | (Default: False) Enable deletion detection in fast sync mode. When enabled, records that exist in the target table but not in the stage table will be marked as deleted by setting the `_SDC_DELETED_AT` timestamp. Requires `add_metadata_columns` to be enabled, tables to have primary keys defined, and `FULL_TABLE` replication method. This option only works with `FULL_TABLE` replication method and does not work with incremental updates or full refresh mode. |
 | cleanup_s3_files                    | Boolean |    No      | (Default: True) **Fast sync mode only.** Automatically clean up S3 files after they have been successfully loaded into Redshift. When set to False, S3 files will be retained after loading. This is useful for debugging or when you need to keep the exported files for other purposes. This setting only applies to fast sync operations and has no effect in regular sync mode. |
+| iceberg_enabled                     | Boolean |    No      | (Default: False) **Fast sync mode only.** When true, fast sync loads data into Apache Iceberg tables (via AWS Glue catalog) instead of Redshift. Requires `iceberg_catalog_name` and `iceberg_namespace`. |
+| iceberg_catalog_name                | String  |    No      | **Fast sync Iceberg only.** Name of the Iceberg catalog (e.g. Glue catalog name) to use when `iceberg_enabled` is true. |
+| iceberg_namespace                   | String  |    No      | **Fast sync Iceberg only.** Iceberg namespace (database/schema) for table creation when `iceberg_enabled` is true. |
 | compression                         | String  |    No        | The compression method to use when writing files to S3 and running Redshift `COPY`. The currently supported methods are `gzip` or `bzip2`. Defaults to none (`""`). |
 | slices                              | Integer |    No      | The number of slices to split files into prior to running COPY on Redshift. This should be set to the number of Redshift slices. The number of slices per node depends on the node size of the cluster - run `SELECT COUNT(DISTINCT slice) slices FROM stv_slices` to calculate this. Defaults to `1`. |
 | temp_dir                            | String  |            | (Default: platform-dependent) Directory of temporary CSV files with RECORD messages. |
@@ -198,6 +201,67 @@ However, ensure your Redshift cluster has the proper IAM role configured:
 ```
 
 For more information about setting up fast sync on the tap side, see the [tap-postgres Fast Sync documentation](https://github.com/Kaligo/pipelinewise-tap-postgres?tab=readme-ov-file#fast-sync-rds-requirements).
+
+#### Fast Sync Iceberg
+
+When **Iceberg** is enabled, fast sync loads data into **Apache Iceberg** tables instead of Redshift. This is useful when you want to land data in a lakehouse (e.g. S3 + Glue) for querying with engines like Spark, Trino, or Athena, while still using the same tap and fast sync pipeline.
+
+##### How Fast Sync Iceberg Works
+
+1. **Same trigger as Fast Sync**: The tap exports data to S3 and embeds `fast_sync_s3_info` in STATE messages.
+2. **Target behaviour**: When `iceberg_enabled` is true, the target uses `FastSyncIcebergLoader` instead of the Redshift loader for each fast sync operation.
+3. **Per stream**:
+   - Reads the **source Parquet schema** from the S3 path.
+   - Uses the **AWS Glue** catalog to create the namespace (if missing) and the Iceberg table (if missing).
+   - **Evolves the Iceberg table schema** to match the source (add columns by name, remove columns that no longer exist in the source).
+   - **Adds the source Parquet file(s)** to the Iceberg table as new data files (no rewrite; append-only at the file level).
+4. **Table layout**:
+   - **Identifier**: `{iceberg_namespace}.{stream_name}` (stream name with `-` replaced by `_`).
+   - **Location**: `s3://{s3_bucket}/iceberg/{iceberg_namespace}/{table_name}`.
+   - **Partitioning**: By day on `_sdc_batched_at` (e.g. `_sdc_batched_at_day`).
+   - **Sort order**: Ascending on `_sdc_batched_at`, nulls first.
+
+##### Fast Sync Iceberg Requirements
+
+- **Fast sync**: Must be used with a tap that supports fast sync and exports to S3 (e.g. tap-postgres fast sync).
+- **Source format**: Source data in S3 must be **Parquet**; the loader reads schema and metadata from it.
+- **AWS Glue catalog**: The Iceberg catalog is **Glue**; the Glue catalog name is set via `iceberg_catalog_name`.
+- **AWS credentials**: Same as for the target (e.g. `aws_access_key_id`, `aws_secret_access_key`, optional `aws_session_token`); used for Glue and S3.
+- **S3 bucket**: The same `s3_bucket` as in config is used; Iceberg table data is stored under `s3://{s3_bucket}/iceberg/{iceberg_namespace}/{table_name}`.
+
+##### Fast Sync Iceberg Configuration
+
+| Property               | Type    | Required? | Description                                                                 |
+|------------------------|---------|-----------|-----------------------------------------------------------------------------|
+| iceberg_enabled        | Boolean | No        | (Default: False) When true, fast sync loads into Iceberg instead of Redshift. |
+| iceberg_catalog_name   | String  | Yes*      | *Required if iceberg_enabled is true.* Glue catalog name for Iceberg.       |
+| iceberg_namespace     | String  | Yes*      | *Required if iceberg_enabled is true.* Iceberg namespace (e.g. database name). |
+
+Example with Iceberg:
+
+```json
+{
+  "host": "xxxxxx.redshift.amazonaws.com",
+  "port": 5439,
+  "user": "my_user",
+  "password": "password",
+  "dbname": "database_name",
+  "aws_access_key_id": "secret",
+  "aws_secret_access_key": "secret",
+  "s3_bucket": "my-bucket",
+  "default_target_schema": "my_schema",
+  "iceberg_enabled": true,
+  "iceberg_catalog_name": "glue_catalog",
+  "iceberg_namespace": "my_iceberg_db"
+}
+```
+
+##### Fast Sync Iceberg Benefits
+
+- **Lakehouse landing**: Data lands in Iceberg on S3, queryable by Spark, Trino, Athena, etc.
+- **Schema evolution**: Table schema is updated to match the source (add/remove columns).
+- **Efficient appends**: New syncs add files to the table without rewriting existing data.
+- **Partitioning and ordering**: Day partitioning and sort order on `_sdc_batched_at` support time-based pruning and ordering.
 
 ### To run tests:
 

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
         'urllib3>=2.6.1,<3.0.0; python_version >= "3.10"',
         'urllib3>=1.25.4,<1.27; python_version < "3.10"',
         "pyiceberg>0.10.0",
-        "pyarrow==23.0.0"
+        "pyarrow==23.0.0",
         'statsd==4.0.1',
     ],
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,8 @@ setup(
         "joblib>=1.5.0",
         'urllib3>=2.6.1,<3.0.0; python_version >= "3.10"',
         'urllib3>=1.25.4,<1.27; python_version < "3.10"',
+        "pyiceberg>0.10.0",
+        "pyarrow==23.0.0"
     ],
     extras_require={
         "test": ["pylint>=2.17.0", "pytest==6.2.5", "mock==3.0.5", "coverage==4.5.4"]
@@ -34,7 +36,10 @@ setup(
           [console_scripts]
           target-redshift=target_redshift:main
       """,
-    packages=["target_redshift", "target_redshift.fast_sync"],
+    packages=[
+        "target_redshift",
+        "target_redshift.fast_sync",
+    ],
     package_data={},
     include_package_data=True,
 )

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ setup(
     packages=[
         "target_redshift",
         "target_redshift.fast_sync",
+        "target_redshift.fast_sync.iceberg"
     ],
     package_data={},
     include_package_data=True,

--- a/target_redshift/__init__.py
+++ b/target_redshift/__init__.py
@@ -95,7 +95,9 @@ def emit_state(state):
         sys.stdout.flush()
 
 
-def flush_fast_sync_queue(fast_sync_queue, stream_to_sync, config, flushed_state=None):  # pylint: disable=too-many-arguments
+def flush_fast_sync_queue(
+    fast_sync_queue, stream_to_sync, config, flushed_state=None
+):  # pylint: disable=too-many-arguments
     """Flush queued fast sync operations with parallelism from config and clear the queue.
 
     Optionally cleans up fast_sync_s3_info from flushed_state bookmarks for processed streams.
@@ -111,8 +113,9 @@ def flush_fast_sync_queue(fast_sync_queue, stream_to_sync, config, flushed_state
 
     parallelism = config.get("parallelism", DEFAULT_PARALLELISM)
     max_parallelism = config.get("max_parallelism", DEFAULT_MAX_PARALLELISM)
+    iceberg_enabled = config.get("iceberg_enabled", False)
     fast_sync_handler.flush_operations(
-        fast_sync_queue, stream_to_sync, parallelism, max_parallelism
+        fast_sync_queue, stream_to_sync, parallelism, max_parallelism, iceberg_enabled
     )
 
     # Clean up fast_sync_s3_info from flushed_state if provided
@@ -163,7 +166,9 @@ def persist_lines(config, lines, table_cache=None) -> None:
     row_count = {}
     stream_to_sync = {}
     total_row_count = {}
-    fast_sync_queue = {}  # Queue for fast_sync_s3_info operations (extracted from STATE messages) to process in parallel
+    fast_sync_queue = (
+        {}
+    )  # Queue for fast_sync_s3_info operations (extracted from STATE messages) to process in parallel
     batch_size_rows = config.get("batch_size_rows", DEFAULT_BATCH_SIZE_ROWS)
 
     # Loop over lines from stdin

--- a/target_redshift/db_sync.py
+++ b/target_redshift/db_sync.py
@@ -299,14 +299,13 @@ class DbSync:
                 aws_secret_access_key=aws_secret_access_key,
                 aws_session_token=aws_session_token,
             )
-            credentials = aws_session.get_credentials().get_frozen_credentials()
-
-            # Explicitly set credentials to those fetched from Boto so we can re-use them in COPY SQL if necessary
-            self.connection_config["aws_access_key_id"] = credentials.access_key
-            self.connection_config["aws_secret_access_key"] = credentials.secret_key
-            self.connection_config["aws_session_token"] = credentials.token
         else:
             aws_session = boto3.session.Session(profile_name=aws_profile)
+
+        credentials = aws_session.get_credentials().get_frozen_credentials()
+        self.connection_config["aws_access_key_id"] = credentials.access_key
+        self.connection_config["aws_secret_access_key"] = credentials.secret_key
+        self.connection_config["aws_session_token"] = credentials.token
 
         self.s3 = aws_session.client("s3")
         self.skip_updates = self.connection_config.get("skip_updates", False)

--- a/target_redshift/fast_sync/handler.py
+++ b/target_redshift/fast_sync/handler.py
@@ -122,7 +122,12 @@ def load_from_s3(
         )
         if iceberg_enabled:
             LOGGER.info("Loading to iceberg for stream %s", stream)
-            loader = FastSyncIcebergLoader(db_sync, s3_info)
+            loader = FastSyncIcebergLoader(
+                logger=db_sync.logger,
+                stream=db_sync.stream_schema_message["stream"],
+                connection_config=db_sync.connection_config,
+                stream_s3_info=s3_info,
+            )
             loader.load_from_s3()
         else:
             loader = FastSyncLoader(db_sync)

--- a/target_redshift/fast_sync/handler.py
+++ b/target_redshift/fast_sync/handler.py
@@ -40,9 +40,8 @@ def validate_and_extract_message(
     # Required fields for fast_sync_s3_info (embedded in STATE message)
     required_fields = [
         "s3_bucket",
-        "s3_path",
+        "s3_paths",
         "s3_region",
-        "files_uploaded",
         "replication_method",
     ]
     missing_fields = [field for field in required_fields if field not in message]
@@ -119,7 +118,7 @@ def load_from_s3(
             FAST_SYNC_S3_INFO_KEY,
             stream,
             s3_info.s3_bucket,
-            s3_info.s3_path,
+            s3_info.base_s3_path,
         )
         if iceberg_enabled:
             LOGGER.info("Loading to iceberg for stream %s", stream)

--- a/target_redshift/fast_sync/iceberg/iceberg_loader.py
+++ b/target_redshift/fast_sync/iceberg/iceberg_loader.py
@@ -16,7 +16,7 @@ class FastSyncIcebergLoader:
     ):
         self.logger = db_sync.logger
         self.connection_config = db_sync.connection_config
-        self.catalog_name = self.connection_config.get("iceberg_catalog_name")
+        self.catalog_name = "ascenda_lakehouse"
         self.namespace = self.connection_config.get("namespace")
         self.iceberg_table_name = f"{self.namespace}.{db_sync.stream_schema_message["stream"].replace('-', '_')}"
         # Make it simpler for now, just one partition column

--- a/target_redshift/fast_sync/iceberg/iceberg_loader.py
+++ b/target_redshift/fast_sync/iceberg/iceberg_loader.py
@@ -1,0 +1,131 @@
+import pyarrow as pa
+from pyiceberg.catalog import load_catalog, Catalog
+from pyiceberg.table import Table
+from pyiceberg.table.sorting import NullOrder
+from pyiceberg.transforms import DayTransform, IdentityTransform
+
+from target_redshift.fast_sync.loader import FastSyncS3Info
+from target_redshift.db_sync import DbSync
+
+
+class FastSyncIcebergLoader:
+    def __init__(
+        self,
+        db_sync: DbSync,
+        stream_s3_info: FastSyncS3Info,
+    ):
+        self.logger = db_sync.logger
+        self.connection_config = db_sync.connection_config
+        self.catalog_name = self.connection_config.get("iceberg_catalog_name")
+        self.namespace = self.connection_config.get("namespace")
+        self.iceberg_table_name = f"{self.namespace}.{db_sync.stream_schema_message["stream"].replace('-', '_')}"
+        # Make it simpler for now, just one partition column
+        self.partition_column = "_sdc_batched_at"
+        self.s3_region = stream_s3_info.s3_region
+        self.s3_bucket = stream_s3_info.s3_bucket
+        self.source_s3_path = f"s3://{self.s3_bucket}/{stream_s3_info.s3_path}"
+
+        self._source_schema = None
+        self._iceberg_catalog = None
+        self._iceberg_table = None
+
+    @staticmethod
+    def _sync_iceberg_table_schema(table: Table, source_schema: pa.Schema):
+        """
+        Evolve the iceberg table schema to match the source schema
+        """
+        to_delete = set(source_schema.names) - set(table.schema().as_arrow().names)
+
+        with table.transaction() as txt:
+            with txt.update_schema() as update:
+                update.union_by_name(source_schema)
+
+                for column_name in to_delete:
+                    update.delete_column(column_name)
+
+    @staticmethod
+    def _sync_iceberg_table_data(table: Table, source_s3_path: str):
+        """
+        Sync the iceberg table data from the source S3 path
+        This based on the assumption the source data file already has static schema.
+        """
+
+        with table.transaction() as txt:
+            txt.add_files(
+                file_paths=[source_s3_path],
+                check_duplicate_files=True,
+            )
+
+    def _load_source_schema(self) -> pa.Schema:
+        """
+        Get the source schema from the source S3 path
+        """
+        if not self._source_schema:
+            self._source_schema = pa.parquet.read_schema(
+                self.source_s3_path,
+                filesystem=pa.fs.S3FileSystem(
+                    region=self.s3_region,
+                    access_key=self.connection_config.get("aws_access_key_id"),
+                    secret_key=self.connection_config.get("aws_secret_access_key"),
+                    session_token=self.connection_config.get("aws_session_token"),
+                ),
+            )
+        return self._source_schema
+
+    def _load_iceberg_catalog(self) -> Catalog:
+        """
+        Load the iceberg catalog and create a namespace if it doesn't exist
+        """
+        if not self._iceberg_catalog:
+            catalog_props = {
+                "type": "glue",
+                "client.region": self.s3_region,
+                "client.access-key-id": self.connection_config.get("aws_access_key_id"),
+                "client.secret-access-key": self.connection_config.get(
+                    "aws_secret_access_key"
+                ),
+                "client.session-token": self.connection_config.get("aws_session_token"),
+            }
+            self._iceberg_catalog = load_catalog(self.catalog_name, **catalog_props)
+            self._iceberg_catalog.create_namespace_if_not_exists(self.namespace)
+        return self._iceberg_catalog
+
+    def _load_iceberg_table(self, catalog: Catalog, schema: pa.Schema) -> Table:
+        """
+        Load the iceberg table and create it if it doesn't exist
+        """
+        if not self._iceberg_table:
+            if catalog.table_exists(self.iceberg_table_name):
+                self._iceberg_table = catalog.load_table(self.iceberg_table_name)
+            else:
+                self._iceberg_table = catalog.create_table(
+                    identifier=self.iceberg_table_name,
+                    schema=schema,
+                )
+                with self._iceberg_table.transaction() as txt:
+                    with txt.update_spec() as update:
+                        update.add_field(
+                            source_column_name=self.partition_column,
+                            transform=DayTransform(),
+                            partition_field_name=f"{self.partition_column}_day",
+                        )
+                    with txt.update_sort_order() as update:
+                        update.asc(
+                            source_column_name=self.partition_column,
+                            transform=IdentityTransform(),
+                            null_order=NullOrder.NULLS_FIRST,
+                        )
+        return self._iceberg_table
+
+    def load_from_s3(self):
+        """
+        Load the iceberg table data from the source S3 path
+        """
+
+        catalog = self._load_iceberg_catalog()
+        source_schema = self._load_source_schema()
+        table = self._load_iceberg_table(catalog, source_schema)
+
+        # Syncing iceberg table schema and data
+        self._sync_iceberg_table_schema(table, source_schema)
+        self._sync_iceberg_table_data(table, self.source_s3_path)

--- a/target_redshift/fast_sync/iceberg/iceberg_loader.py
+++ b/target_redshift/fast_sync/iceberg/iceberg_loader.py
@@ -1,4 +1,6 @@
 import pyarrow as pa
+import pyarrow.parquet as pq
+import pyarrow.fs as fs
 from pyiceberg.catalog import load_catalog, Catalog
 from pyiceberg.table import Table
 from pyiceberg.table.sorting import NullOrder
@@ -17,14 +19,15 @@ class FastSyncIcebergLoader:
         self.logger = db_sync.logger
         self.connection_config = db_sync.connection_config
         self.catalog_name = db_sync.connection_config.get("iceberg_catalog_name")
-        self.namespace = self.connection_config.get("iceberg_namespace")
-        self.iceberg_table_name = f"{self.namespace}.{db_sync.stream_schema_message["stream"].replace('-', '_')}"
+        self.iceberg_namespace = self.connection_config.get("iceberg_namespace")
+        self.iceberg_table = db_sync.stream_schema_message["stream"].replace("-", "_")
+        self.iceberg_table_identifier = f"{self.iceberg_namespace}.{self.iceberg_table}"
         # Make it simpler for now, just one partition column
         self.partition_column = "_sdc_batched_at"
         self.s3_region = stream_s3_info.s3_region
         self.s3_bucket = stream_s3_info.s3_bucket
-        self.source_s3_path = f"s3://{self.s3_bucket}/{stream_s3_info.s3_path}"
-
+        self.source_s3_path = f"{self.s3_bucket}/{stream_s3_info.s3_path}"
+        self.iceberg_table_location = f"s3://{self.s3_bucket}/iceberg/{self.iceberg_namespace}/{self.iceberg_table}"
         self._source_schema = None
         self._iceberg_catalog = None
         self._iceberg_table = None
@@ -61,9 +64,9 @@ class FastSyncIcebergLoader:
         Get the source schema from the source S3 path
         """
         if not self._source_schema:
-            self._source_schema = pa.parquet.read_schema(
+            self._source_schema = pq.read_schema(
                 self.source_s3_path,
-                filesystem=pa.fs.S3FileSystem(
+                filesystem=fs.S3FileSystem(
                     region=self.s3_region,
                     access_key=self.connection_config.get("aws_access_key_id"),
                     secret_key=self.connection_config.get("aws_secret_access_key"),
@@ -87,7 +90,7 @@ class FastSyncIcebergLoader:
                 "client.session-token": self.connection_config.get("aws_session_token"),
             }
             self._iceberg_catalog = load_catalog(self.catalog_name, **catalog_props)
-            self._iceberg_catalog.create_namespace_if_not_exists(self.namespace)
+            self._iceberg_catalog.create_namespace_if_not_exists(self.iceberg_namespace)
         return self._iceberg_catalog
 
     def _load_iceberg_table(self, catalog: Catalog, schema: pa.Schema) -> Table:
@@ -95,12 +98,13 @@ class FastSyncIcebergLoader:
         Load the iceberg table and create it if it doesn't exist
         """
         if not self._iceberg_table:
-            if catalog.table_exists(self.iceberg_table_name):
-                self._iceberg_table = catalog.load_table(self.iceberg_table_name)
+            if catalog.table_exists(self.iceberg_table_identifier):
+                self._iceberg_table = catalog.load_table(self.iceberg_table_identifier)
             else:
                 self._iceberg_table = catalog.create_table(
-                    identifier=self.iceberg_table_name,
+                    identifier=self.iceberg_table_identifier,
                     schema=schema,
+                    location=self.iceberg_table_location,
                 )
                 with self._iceberg_table.transaction() as txt:
                     with txt.update_spec() as update:
@@ -128,4 +132,4 @@ class FastSyncIcebergLoader:
 
         # Syncing iceberg table schema and data
         self._sync_iceberg_table_schema(table, source_schema)
-        self._sync_iceberg_table_data(table, self.source_s3_path)
+        self._sync_iceberg_table_data(table, f"s3://{self.source_s3_path}")

--- a/target_redshift/fast_sync/iceberg/iceberg_loader.py
+++ b/target_redshift/fast_sync/iceberg/iceberg_loader.py
@@ -1,5 +1,6 @@
-from typing import List
+from typing import Any, Dict, List
 from functools import cached_property
+import logging
 
 import pyarrow as pa
 from pyiceberg.catalog import load_catalog, Catalog
@@ -8,13 +9,14 @@ from pyiceberg.table.sorting import NullOrder
 from pyiceberg.transforms import DayTransform, IdentityTransform
 
 from target_redshift.fast_sync.loader import FastSyncS3Info
-from target_redshift.db_sync import DbSync
 
 
 class FastSyncIcebergLoader:
     def __init__(
         self,
-        db_sync: DbSync,
+        logger: logging.Logger,
+        stream: str,
+        connection_config: Dict[str, Any],
         stream_s3_info: FastSyncS3Info,
     ):
 
@@ -23,12 +25,12 @@ class FastSyncIcebergLoader:
                 f"Unsupported file format: {stream_s3_info.file_format}. Should be one of: parquet, orc, avro"
             )
 
-        self.logger = db_sync.logger
-        self.connection_config = db_sync.connection_config
-        self.stream = db_sync.stream_schema_message["stream"]
-        self.catalog_name = db_sync.connection_config.get("iceberg_catalog_name")
-        self.iceberg_namespace = self.connection_config.get("iceberg_namespace")
-        self.iceberg_s3_prefix = self.connection_config.get("iceberg_s3_prefix")
+        self.logger = logger
+        self.stream = stream
+        self.connection_config = connection_config
+        self.catalog_name = connection_config.get("iceberg_catalog_name")
+        self.iceberg_namespace = connection_config.get("iceberg_namespace")
+        self.iceberg_s3_prefix = connection_config.get("iceberg_s3_prefix")
         self.source_schema = stream_s3_info.pyarrow_schema
         # Make it simpler for now, just one partition column
         self.partition_column = stream_s3_info.partition_column or "_sdc_batched_at"
@@ -87,9 +89,7 @@ class FastSyncIcebergLoader:
             "type": "glue",
             "client.region": self.s3_region,
             "client.access-key-id": self.connection_config.get("aws_access_key_id"),
-            "client.secret-access-key": self.connection_config.get(
-                "aws_secret_access_key"
-            ),
+            "client.secret-access-key": self.connection_config.get("aws_secret_access_key"),
             "client.session-token": self.connection_config.get("aws_session_token"),
         }
         iceberg_catalog = load_catalog(self.catalog_name, **catalog_props)

--- a/target_redshift/fast_sync/iceberg/iceberg_loader.py
+++ b/target_redshift/fast_sync/iceberg/iceberg_loader.py
@@ -32,7 +32,7 @@ class FastSyncIcebergLoader:
         self.partition_column = "_sdc_batched_at"
         self.s3_region = stream_s3_info.s3_region
         self.s3_bucket = stream_s3_info.s3_bucket
-        self.source_s3_path = f"{self.s3_bucket}/{stream_s3_info.s3_path}"
+        self.source_s3_path = f"s3://{self.s3_bucket}/{stream_s3_info.s3_path}"
         self.number_of_files = stream_s3_info.files_uploaded
         self.iceberg_table_location = f"s3://{self.s3_bucket}/iceberg/{self.iceberg_namespace}/{self.iceberg_table}"
         self._source_schema = None

--- a/target_redshift/fast_sync/iceberg/iceberg_loader.py
+++ b/target_redshift/fast_sync/iceberg/iceberg_loader.py
@@ -1,3 +1,5 @@
+from functools import cached_property, lru_cache
+
 import pyarrow as pa
 import pyarrow.parquet as pq
 import pyarrow.fs as fs
@@ -24,32 +26,49 @@ class FastSyncIcebergLoader:
 
         self.logger = db_sync.logger
         self.connection_config = db_sync.connection_config
+        self.stream = db_sync.stream_schema_message["stream"]
         self.catalog_name = db_sync.connection_config.get("iceberg_catalog_name")
         self.iceberg_namespace = self.connection_config.get("iceberg_namespace")
-        self.iceberg_table = db_sync.stream_schema_message["stream"].replace("-", "_")
-        self.iceberg_table_identifier = f"{self.iceberg_namespace}.{self.iceberg_table}"
         # Make it simpler for now, just one partition column
         self.partition_column = "_sdc_batched_at"
         self.s3_region = stream_s3_info.s3_region
         self.s3_bucket = stream_s3_info.s3_bucket
-        self.source_s3_path = f"{self.s3_bucket}/{stream_s3_info.s3_path}"
+        self.s3_key = stream_s3_info.s3_path
         self.number_of_files = stream_s3_info.files_uploaded
-        self.iceberg_table_location = f"s3://{self.s3_bucket}/iceberg/{self.iceberg_namespace}/{self.iceberg_table}"
-        self._source_schema = None
-        self._iceberg_catalog = None
-        self._iceberg_table = None
+        self._load_source_schema = lru_cache(self._load_source_schema)
 
-    def _iterate_source_s3_path(self, s3_path: str, number_of_files: int):
-        for part_num in range(1, number_of_files + 1):
-            if number_of_files > 1:
-                yield f"{s3_path}_part{part_num}"
+    @property
+    def iceberg_table(self) -> str:
+        """Iceberg table name derived from the stream name, with hyphens normalised to underscores."""
+        return self.stream.replace("-", "_")
+
+    @property
+    def iceberg_table_identifier(self) -> str:
+        """Fully-qualified Iceberg table identifier: <namespace>.<table>."""
+        return f"{self.iceberg_namespace}.{self.iceberg_table}"
+
+    @property
+    def source_s3_path(self) -> str:
+        """Full S3 path to the source data files (bucket/key prefix, no s3:// scheme)."""
+        return f"{self.s3_bucket}/{self.s3_key}"
+
+    @property
+    def iceberg_table_location(self) -> str:
+        """S3 URI where the Iceberg table data is stored."""
+        return f"s3://{self.s3_bucket}/iceberg/{self.iceberg_namespace}/{self.iceberg_table}"
+
+    def _iterate_source_s3_path(self):
+        for part_num in range(1, self.number_of_files + 1):
+            if self.number_of_files > 1:
+                yield f"{self.source_s3_path}_part{part_num}"
             else:
-                yield s3_path
+                yield self.source_s3_path
 
-    def _sync_iceberg_table_schema(self, table: Table, source_schema: pa.Schema):
+    def _sync_iceberg_table(self, table: Table, s3_file_path: str):
         """
-        Evolve the iceberg table schema to match the source schema
+        Sync the iceberg table schema and data from the source S3 path
         """
+        source_schema = self._load_source_schema(s3_file_path)
         to_delete = set(source_schema.names) - set(table.schema().as_arrow().names)
 
         with table.transaction() as txt:
@@ -58,95 +77,82 @@ class FastSyncIcebergLoader:
 
                 for column_name in to_delete:
                     update.delete_column(column_name)
-
-    def _sync_iceberg_table_data(self, table: Table, s3_file_path: str):
-        """
-        Sync the iceberg table data from the source S3 path
-        This based on the assumption the source data file already has static schema.
-        """
-        with table.transaction() as txt:
             txt.add_files(
                 # s3_file_path is bucket/key (from _iterate_source_s3_path); add_files expects a full s3:// URI, so we prepend the prefix.
                 file_paths=[f"s3://{s3_file_path}"],
                 check_duplicate_files=True,
             )
 
+    @cached_property
+    def iceberg_catalog(self) -> Catalog:
+        """
+        Load the iceberg catalog and create a namespace if it doesn't exist
+        """
+        catalog_props = {
+            "type": "glue",
+            "client.region": self.s3_region,
+            "client.access-key-id": self.connection_config.get("aws_access_key_id"),
+            "client.secret-access-key": self.connection_config.get(
+                "aws_secret_access_key"
+            ),
+            "client.session-token": self.connection_config.get("aws_session_token"),
+        }
+        iceberg_catalog = load_catalog(self.catalog_name, **catalog_props)
+        iceberg_catalog.create_namespace_if_not_exists(self.iceberg_namespace)
+        return iceberg_catalog
+
     def _load_source_schema(self, s3_file_path: str) -> pa.Schema:
         """
         Get the source schema from the source S3 path
         """
-        if not self._source_schema:
-            self._source_schema = pq.read_schema(
-                # s3_file_path must be bucket/key (no s3://); PyArrow S3FileSystem rejects URIs.
-                s3_file_path,
-                filesystem=fs.S3FileSystem(
-                    region=self.s3_region,
-                    access_key=self.connection_config.get("aws_access_key_id"),
-                    secret_key=self.connection_config.get("aws_secret_access_key"),
-                    session_token=self.connection_config.get("aws_session_token"),
-                ),
-            )
-        return self._source_schema
+        return pq.read_schema(
+            # s3_file_path must be bucket/key (no s3://); PyArrow S3FileSystem rejects URIs.
+            s3_file_path,
+            filesystem=fs.S3FileSystem(
+                region=self.s3_region,
+                access_key=self.connection_config.get("aws_access_key_id"),
+                secret_key=self.connection_config.get("aws_secret_access_key"),
+                session_token=self.connection_config.get("aws_session_token"),
+            ),
+        )
 
-    def _load_iceberg_catalog(self) -> Catalog:
-        """
-        Load the iceberg catalog and create a namespace if it doesn't exist
-        """
-        if not self._iceberg_catalog:
-            catalog_props = {
-                "type": "glue",
-                "client.region": self.s3_region,
-                "client.access-key-id": self.connection_config.get("aws_access_key_id"),
-                "client.secret-access-key": self.connection_config.get(
-                    "aws_secret_access_key"
-                ),
-                "client.session-token": self.connection_config.get("aws_session_token"),
-            }
-            self._iceberg_catalog = load_catalog(self.catalog_name, **catalog_props)
-            self._iceberg_catalog.create_namespace_if_not_exists(self.iceberg_namespace)
-        return self._iceberg_catalog
-
-    def _load_iceberg_table(self, catalog: Catalog, schema: pa.Schema) -> Table:
+    def _load_iceberg_table(self, schema: pa.Schema) -> Table:
         """
         Load the iceberg table and create it if it doesn't exist
         """
-        if not self._iceberg_table:
-            if catalog.table_exists(self.iceberg_table_identifier):
-                self._iceberg_table = catalog.load_table(self.iceberg_table_identifier)
-            else:
-                self._iceberg_table = catalog.create_table(
-                    identifier=self.iceberg_table_identifier,
-                    schema=schema,
-                    location=self.iceberg_table_location,
-                )
-                with self._iceberg_table.transaction() as txt:
-                    with txt.update_spec() as update:
-                        update.add_field(
-                            source_column_name=self.partition_column,
-                            transform=DayTransform(),
-                            partition_field_name=f"{self.partition_column}_day",
-                        )
-                    with txt.update_sort_order() as update:
-                        update.asc(
-                            source_column_name=self.partition_column,
-                            transform=IdentityTransform(),
-                            null_order=NullOrder.NULLS_FIRST,
-                        )
-        return self._iceberg_table
+        if self.iceberg_catalog.table_exists(self.iceberg_table_identifier):
+            iceberg_table = self.iceberg_catalog.load_table(
+                self.iceberg_table_identifier
+            )
+        else:
+            iceberg_table = self.iceberg_catalog.create_table(
+                identifier=self.iceberg_table_identifier,
+                schema=schema,
+                location=self.iceberg_table_location,
+            )
+            with iceberg_table.transaction() as txt:
+                with txt.update_spec() as update:
+                    update.add_field(
+                        source_column_name=self.partition_column,
+                        transform=DayTransform(),
+                        partition_field_name=f"{self.partition_column}_day",
+                    )
+                with txt.update_sort_order() as update:
+                    update.asc(
+                        source_column_name=self.partition_column,
+                        transform=IdentityTransform(),
+                        null_order=NullOrder.NULLS_FIRST,
+                    )
+        return iceberg_table
 
     def load_from_s3(self):
         """
         Load the iceberg table data from the source S3 path
         """
-
-        for s3_file_path in self._iterate_source_s3_path(
-            self.source_s3_path, self.number_of_files
-        ):
+        file_paths = list(self._iterate_source_s3_path())
+        iceberg_table = self._load_iceberg_table(
+            self._load_source_schema(file_paths[0])
+        )
+        for s3_file_path in file_paths:
             self.logger.info("Loading iceberg table data from %s", s3_file_path)
-            catalog = self._load_iceberg_catalog()
-            source_schema = self._load_source_schema(s3_file_path)
-            table = self._load_iceberg_table(catalog, source_schema)
-
-            # Syncing iceberg table schema and data
-            self._sync_iceberg_table_schema(table, source_schema)
-            self._sync_iceberg_table_data(table, s3_file_path)
+            self._sync_iceberg_table(iceberg_table, s3_file_path)

--- a/target_redshift/fast_sync/iceberg/iceberg_loader.py
+++ b/target_redshift/fast_sync/iceberg/iceberg_loader.py
@@ -16,6 +16,12 @@ class FastSyncIcebergLoader:
         db_sync: DbSync,
         stream_s3_info: FastSyncS3Info,
     ):
+
+        if stream_s3_info.file_format not in ("parquet", "orc", "avro"):
+            raise ValueError(
+                f"Unsupported file format: {stream_s3_info.file_format}. Should be one of: parquet, orc, avro"
+            )
+
         self.logger = db_sync.logger
         self.connection_config = db_sync.connection_config
         self.catalog_name = db_sync.connection_config.get("iceberg_catalog_name")
@@ -27,13 +33,20 @@ class FastSyncIcebergLoader:
         self.s3_region = stream_s3_info.s3_region
         self.s3_bucket = stream_s3_info.s3_bucket
         self.source_s3_path = f"{self.s3_bucket}/{stream_s3_info.s3_path}"
+        self.number_of_files = stream_s3_info.files_uploaded
         self.iceberg_table_location = f"s3://{self.s3_bucket}/iceberg/{self.iceberg_namespace}/{self.iceberg_table}"
         self._source_schema = None
         self._iceberg_catalog = None
         self._iceberg_table = None
 
-    @staticmethod
-    def _sync_iceberg_table_schema(table: Table, source_schema: pa.Schema):
+    def _iterate_source_s3_path(self, s3_path: str, number_of_files: int):
+        for part_num in range(1, number_of_files + 1):
+            if number_of_files > 1:
+                yield f"{s3_path}_part{part_num}"
+            else:
+                yield s3_path
+
+    def _sync_iceberg_table_schema(self, table: Table, source_schema: pa.Schema):
         """
         Evolve the iceberg table schema to match the source schema
         """
@@ -46,26 +59,24 @@ class FastSyncIcebergLoader:
                 for column_name in to_delete:
                     update.delete_column(column_name)
 
-    @staticmethod
-    def _sync_iceberg_table_data(table: Table, source_s3_path: str):
+    def _sync_iceberg_table_data(self, table: Table, s3_file_path: str):
         """
         Sync the iceberg table data from the source S3 path
         This based on the assumption the source data file already has static schema.
         """
-
         with table.transaction() as txt:
             txt.add_files(
-                file_paths=[source_s3_path],
+                file_paths=[s3_file_path],
                 check_duplicate_files=True,
             )
 
-    def _load_source_schema(self) -> pa.Schema:
+    def _load_source_schema(self, s3_file_path: str) -> pa.Schema:
         """
         Get the source schema from the source S3 path
         """
         if not self._source_schema:
             self._source_schema = pq.read_schema(
-                self.source_s3_path,
+                s3_file_path,
                 filesystem=fs.S3FileSystem(
                     region=self.s3_region,
                     access_key=self.connection_config.get("aws_access_key_id"),
@@ -126,10 +137,14 @@ class FastSyncIcebergLoader:
         Load the iceberg table data from the source S3 path
         """
 
-        catalog = self._load_iceberg_catalog()
-        source_schema = self._load_source_schema()
-        table = self._load_iceberg_table(catalog, source_schema)
+        for s3_file_path in self._iterate_source_s3_path(
+            self.source_s3_path, self.number_of_files
+        ):
+            self.logger.info("Loading iceberg table data from %s", s3_file_path)
+            catalog = self._load_iceberg_catalog()
+            source_schema = self._load_source_schema(s3_file_path)
+            table = self._load_iceberg_table(catalog, source_schema)
 
-        # Syncing iceberg table schema and data
-        self._sync_iceberg_table_schema(table, source_schema)
-        self._sync_iceberg_table_data(table, f"s3://{self.source_s3_path}")
+            # Syncing iceberg table schema and data
+            self._sync_iceberg_table_schema(table, source_schema)
+            self._sync_iceberg_table_data(table, s3_file_path)

--- a/target_redshift/fast_sync/iceberg/iceberg_loader.py
+++ b/target_redshift/fast_sync/iceberg/iceberg_loader.py
@@ -34,8 +34,7 @@ class FastSyncIcebergLoader:
         self.partition_column = "_sdc_batched_at"
         self.s3_region = stream_s3_info.s3_region
         self.s3_bucket = stream_s3_info.s3_bucket
-        self.s3_key = stream_s3_info.s3_path
-        self.number_of_files = stream_s3_info.files_uploaded
+        self.s3_keys = stream_s3_info.s3_paths
 
     @property
     def iceberg_table(self) -> str:
@@ -48,27 +47,24 @@ class FastSyncIcebergLoader:
         return f"{self.iceberg_namespace}.{self.iceberg_table}"
 
     @property
-    def source_s3_path(self) -> str:
-        """Full S3 path to the source data files (bucket/key prefix, no s3:// scheme)."""
-        return f"{self.s3_bucket}/{self.s3_key}"
-
-    @property
     def iceberg_table_location(self) -> str:
         """S3 URI where the Iceberg table data is stored."""
         return f"s3://{self.s3_bucket}/{self.iceberg_s3_prefix}/{self.stream}"
 
-    def _iterate_source_s3_path(self):
-        for part_num in range(1, self.number_of_files + 1):
-            if self.number_of_files > 1:
-                yield f"{self.source_s3_path}_part{part_num}"
-            else:
-                yield self.source_s3_path
+    @property
+    def source_s3_paths(self) -> List[str]:
+        """List of all S3 paths to the source data files."""
+        return [self._source_s3_path(s3_key) for s3_key in self.s3_keys]
+
+    def _source_s3_path(self, s3_key) -> str:
+        """Full S3 path to the source data files (bucket/key prefix, no s3:// scheme)."""
+        return f"{self.s3_bucket}/{s3_key}"
 
     def _sync_iceberg_table(self, table: Table, s3_file_paths: List[str]):
         """
         Sync the iceberg table schema and data from the source S3 path
         """
-        to_delete = set(table.schema().as_arrow().names) - set(self.source_schema.names) 
+        to_delete = set(table.schema().as_arrow().names) - set(self.source_schema.names)
 
         with table.transaction() as txt:
             with txt.update_schema() as update:
@@ -77,7 +73,7 @@ class FastSyncIcebergLoader:
                 for column_name in to_delete:
                     update.delete_column(column_name)
             txt.add_files(
-                # s3_file_path is bucket/key (from _iterate_source_s3_path); add_files expects a full s3:// URI, so we prepend the prefix.
+                # s3_file_path is bucket/key (from source_s3_paths); add_files expects a full s3:// URI, so we prepend the prefix.
                 file_paths=[f"s3://{s3_file_path}" for s3_file_path in s3_file_paths],
                 check_duplicate_files=True,
             )
@@ -133,7 +129,7 @@ class FastSyncIcebergLoader:
         """
         Load the iceberg table data from the source S3 path
         """
-        file_paths = list(self._iterate_source_s3_path())
+        file_paths = self.source_s3_paths
         iceberg_table = self._load_iceberg_table(self.source_schema)
         self.logger.info("Loading iceberg table data from %s", ", ".join(file_paths))
         self._sync_iceberg_table(iceberg_table, file_paths)

--- a/target_redshift/fast_sync/iceberg/iceberg_loader.py
+++ b/target_redshift/fast_sync/iceberg/iceberg_loader.py
@@ -31,7 +31,7 @@ class FastSyncIcebergLoader:
         self.iceberg_s3_prefix = self.connection_config.get("iceberg_s3_prefix")
         self.source_schema = stream_s3_info.pyarrow_schema
         # Make it simpler for now, just one partition column
-        self.partition_column = "_sdc_batched_at"
+        self.partition_column = stream_s3_info.partition_column or "_sdc_batched_at"
         self.s3_region = stream_s3_info.s3_region
         self.s3_bucket = stream_s3_info.s3_bucket
         self.s3_keys = stream_s3_info.s3_paths

--- a/target_redshift/fast_sync/iceberg/iceberg_loader.py
+++ b/target_redshift/fast_sync/iceberg/iceberg_loader.py
@@ -32,7 +32,7 @@ class FastSyncIcebergLoader:
         self.partition_column = "_sdc_batched_at"
         self.s3_region = stream_s3_info.s3_region
         self.s3_bucket = stream_s3_info.s3_bucket
-        self.source_s3_path = f"s3://{self.s3_bucket}/{stream_s3_info.s3_path}"
+        self.source_s3_path = f"{self.s3_bucket}/{stream_s3_info.s3_path}"
         self.number_of_files = stream_s3_info.files_uploaded
         self.iceberg_table_location = f"s3://{self.s3_bucket}/iceberg/{self.iceberg_namespace}/{self.iceberg_table}"
         self._source_schema = None
@@ -66,7 +66,8 @@ class FastSyncIcebergLoader:
         """
         with table.transaction() as txt:
             txt.add_files(
-                file_paths=[s3_file_path],
+                # s3_file_path is bucket/key (from _iterate_source_s3_path); add_files expects a full s3:// URI, so we prepend the prefix.
+                file_paths=[f"s3://{s3_file_path}"],
                 check_duplicate_files=True,
             )
 
@@ -76,6 +77,7 @@ class FastSyncIcebergLoader:
         """
         if not self._source_schema:
             self._source_schema = pq.read_schema(
+                # s3_file_path must be bucket/key (no s3://); PyArrow S3FileSystem rejects URIs.
                 s3_file_path,
                 filesystem=fs.S3FileSystem(
                     region=self.s3_region,

--- a/target_redshift/fast_sync/iceberg/iceberg_loader.py
+++ b/target_redshift/fast_sync/iceberg/iceberg_loader.py
@@ -1,8 +1,7 @@
-from functools import cached_property, lru_cache
+from typing import List
+from functools import cached_property
 
 import pyarrow as pa
-import pyarrow.parquet as pq
-import pyarrow.fs as fs
 from pyiceberg.catalog import load_catalog, Catalog
 from pyiceberg.table import Table
 from pyiceberg.table.sorting import NullOrder
@@ -29,13 +28,14 @@ class FastSyncIcebergLoader:
         self.stream = db_sync.stream_schema_message["stream"]
         self.catalog_name = db_sync.connection_config.get("iceberg_catalog_name")
         self.iceberg_namespace = self.connection_config.get("iceberg_namespace")
+        self.iceberg_s3_prefix = self.connection_config.get("iceberg_s3_prefix")
+        self.source_schema = stream_s3_info.pyarrow_schema
         # Make it simpler for now, just one partition column
         self.partition_column = "_sdc_batched_at"
         self.s3_region = stream_s3_info.s3_region
         self.s3_bucket = stream_s3_info.s3_bucket
         self.s3_key = stream_s3_info.s3_path
         self.number_of_files = stream_s3_info.files_uploaded
-        self._load_source_schema = lru_cache(self._load_source_schema)
 
     @property
     def iceberg_table(self) -> str:
@@ -55,7 +55,7 @@ class FastSyncIcebergLoader:
     @property
     def iceberg_table_location(self) -> str:
         """S3 URI where the Iceberg table data is stored."""
-        return f"s3://{self.s3_bucket}/iceberg/{self.iceberg_namespace}/{self.iceberg_table}"
+        return f"s3://{self.s3_bucket}/{self.iceberg_s3_prefix}/{self.iceberg_namespace}/{self.iceberg_table}"
 
     def _iterate_source_s3_path(self):
         for part_num in range(1, self.number_of_files + 1):
@@ -64,22 +64,21 @@ class FastSyncIcebergLoader:
             else:
                 yield self.source_s3_path
 
-    def _sync_iceberg_table(self, table: Table, s3_file_path: str):
+    def _sync_iceberg_table(self, table: Table, s3_file_paths: List[str]):
         """
         Sync the iceberg table schema and data from the source S3 path
         """
-        source_schema = self._load_source_schema(s3_file_path)
-        to_delete = set(source_schema.names) - set(table.schema().as_arrow().names)
+        to_delete = set(table.schema().as_arrow().names) - set(self.source_schema.names) 
 
         with table.transaction() as txt:
             with txt.update_schema() as update:
-                update.union_by_name(source_schema)
+                update.union_by_name(self.source_schema)
 
                 for column_name in to_delete:
                     update.delete_column(column_name)
             txt.add_files(
                 # s3_file_path is bucket/key (from _iterate_source_s3_path); add_files expects a full s3:// URI, so we prepend the prefix.
-                file_paths=[f"s3://{s3_file_path}"],
+                file_paths=[f"s3://{s3_file_path}" for s3_file_path in s3_file_paths],
                 check_duplicate_files=True,
             )
 
@@ -100,21 +99,6 @@ class FastSyncIcebergLoader:
         iceberg_catalog = load_catalog(self.catalog_name, **catalog_props)
         iceberg_catalog.create_namespace_if_not_exists(self.iceberg_namespace)
         return iceberg_catalog
-
-    def _load_source_schema(self, s3_file_path: str) -> pa.Schema:
-        """
-        Get the source schema from the source S3 path
-        """
-        return pq.read_schema(
-            # s3_file_path must be bucket/key (no s3://); PyArrow S3FileSystem rejects URIs.
-            s3_file_path,
-            filesystem=fs.S3FileSystem(
-                region=self.s3_region,
-                access_key=self.connection_config.get("aws_access_key_id"),
-                secret_key=self.connection_config.get("aws_secret_access_key"),
-                session_token=self.connection_config.get("aws_session_token"),
-            ),
-        )
 
     def _load_iceberg_table(self, schema: pa.Schema) -> Table:
         """
@@ -150,9 +134,6 @@ class FastSyncIcebergLoader:
         Load the iceberg table data from the source S3 path
         """
         file_paths = list(self._iterate_source_s3_path())
-        iceberg_table = self._load_iceberg_table(
-            self._load_source_schema(file_paths[0])
-        )
-        for s3_file_path in file_paths:
-            self.logger.info("Loading iceberg table data from %s", s3_file_path)
-            self._sync_iceberg_table(iceberg_table, s3_file_path)
+        iceberg_table = self._load_iceberg_table(self.source_schema)
+        self.logger.info("Loading iceberg table data from %s", ", ".join(file_paths))
+        self._sync_iceberg_table(iceberg_table, file_paths)

--- a/target_redshift/fast_sync/iceberg/iceberg_loader.py
+++ b/target_redshift/fast_sync/iceberg/iceberg_loader.py
@@ -55,7 +55,7 @@ class FastSyncIcebergLoader:
     @property
     def iceberg_table_location(self) -> str:
         """S3 URI where the Iceberg table data is stored."""
-        return f"s3://{self.s3_bucket}/{self.iceberg_s3_prefix}/{self.iceberg_namespace}/{self.iceberg_table}"
+        return f"s3://{self.s3_bucket}/{self.iceberg_s3_prefix}/{self.stream}"
 
     def _iterate_source_s3_path(self):
         for part_num in range(1, self.number_of_files + 1):

--- a/target_redshift/fast_sync/loader.py
+++ b/target_redshift/fast_sync/loader.py
@@ -20,9 +20,12 @@ class FastSyncS3Info:
     s3_bucket: str
     s3_path: str
     s3_region: str
-    files_uploaded: int
     replication_method: str
+    file_format: str = "csv"
+    files_uploaded: int = 0
     rows_uploaded: int = 0
+    bytes_uploaded: int = 0
+    time_extracted: str = ""
 
     @classmethod
     def from_message(cls, message: Dict[str, Any]) -> "FastSyncS3Info":
@@ -31,9 +34,12 @@ class FastSyncS3Info:
             s3_bucket=message["s3_bucket"],
             s3_path=message["s3_path"],
             s3_region=message["s3_region"],
-            files_uploaded=message["files_uploaded"],
             replication_method=message["replication_method"],
+            file_format=message.get("file_format", "csv"),
+            files_uploaded=message.get("files_uploaded", 0),
             rows_uploaded=message.get("rows_uploaded", 0),
+            bytes_uploaded=message.get("bytes_uploaded", 0),
+            time_extracted=message.get("time_extracted", ""),
         )
 
 

--- a/target_redshift/fast_sync/loader.py
+++ b/target_redshift/fast_sync/loader.py
@@ -19,11 +19,10 @@ class FastSyncS3Info:
     """Value object representing fast sync S3 information from STATE messages."""
 
     s3_bucket: str
-    s3_path: str
+    s3_paths: List[str]
     s3_region: str
     replication_method: str
     file_format: str = "csv"
-    files_uploaded: int = 0
     rows_uploaded: int = 0
     bytes_uploaded: int = 0
     time_extracted: str = ""
@@ -44,16 +43,20 @@ class FastSyncS3Info:
 
         return cls(
             s3_bucket=message["s3_bucket"],
-            s3_path=message["s3_path"],
+            s3_paths=message["s3_paths"],
             s3_region=message["s3_region"],
             replication_method=message["replication_method"],
             file_format=message.get("file_format", "csv"),
-            files_uploaded=message.get("files_uploaded", 0),
             rows_uploaded=message.get("rows_uploaded", 0),
             bytes_uploaded=message.get("bytes_uploaded", 0),
             time_extracted=message.get("time_extracted", ""),
             pyarrow_schema=pyarrow_schema,
         )
+
+    @property
+    def base_s3_path(self) -> str:
+        # Expect first part is always the base path (common prefix for all files).
+        return self.s3_paths[0]
 
 
 class FastSyncLoader:  # pylint: disable=too-few-public-methods,too-many-instance-attributes
@@ -78,10 +81,7 @@ class FastSyncLoader:  # pylint: disable=too-few-public-methods,too-many-instanc
 
     @staticmethod
     def _build_s3_copy_path(s3_info: FastSyncS3Info) -> str:
-        s3_copy_path = f"s3://{s3_info.s3_bucket}/{s3_info.s3_path}"
-        if s3_info.files_uploaded > 1 and s3_copy_path.endswith(".csv"):
-            s3_copy_path = s3_copy_path[:-4]
-        return s3_copy_path
+        return f"s3://{s3_info.s3_bucket}/{s3_info.base_s3_path}"
 
     def _build_copy_sql(
         self,
@@ -94,6 +94,9 @@ class FastSyncLoader:  # pylint: disable=too-few-public-methods,too-many-instanc
         copy_credentials = self.db_sync.build_copy_credentials()
         copy_options = self.db_sync.build_copy_options(s3_info.s3_region)
 
+        # For multiple files, Redshift COPY can take the common prefix
+        # and it will load all matching files, so we can just use the
+        # base s3 path (first entry in s3_paths) without needing to list all parts here.
         return f"""COPY {table_name} ({column_names})
             FROM '{s3_copy_path}'
             {copy_credentials}
@@ -182,36 +185,21 @@ class FastSyncLoader:  # pylint: disable=too-few-public-methods,too-many-instanc
         return inserts, updates, deletions
 
     def _cleanup_s3_files(self, s3_info: FastSyncS3Info) -> None:
-        try:
-            self.s3_client.delete_object(Bucket=s3_info.s3_bucket, Key=s3_info.s3_path)
-            self.logger.info("Deleted s3://%s/%s", s3_info.s3_bucket, s3_info.s3_path)
-
-            if s3_info.files_uploaded > 1:
-                for part_num in range(2, s3_info.files_uploaded + 1):
-                    if s3_info.s3_path.endswith(".csv"):
-                        part_path = s3_info.s3_path[:-4] + f"_part{part_num}.csv"
-                    else:
-                        part_path = f"{s3_info.s3_path}_part{part_num}.csv"
-                    try:
-                        self.s3_client.delete_object(
-                            Bucket=s3_info.s3_bucket, Key=part_path
-                        )
-                        self.logger.info(
-                            "Deleted s3://%s/%s", s3_info.s3_bucket, part_path
-                        )
-                    except Exception as exc:
-                        self.logger.warning(
-                            "Failed to delete S3 file s3://%s/%s: %s",
-                            s3_info.s3_bucket,
-                            part_path,
-                            str(exc),
-                        )
-        except Exception as exc:
-            self.logger.warning(
-                "Failed to clean up S3 files from bucket %s: %s",
-                s3_info.s3_bucket,
-                str(exc),
-            )
+        for part_path in s3_info.s3_paths:
+            try:
+                self.s3_client.delete_object(
+                    Bucket=s3_info.s3_bucket, Key=part_path
+                )
+                self.logger.info(
+                    "Deleted s3://%s/%s", s3_info.s3_bucket, part_path
+                )
+            except Exception as exc:
+                self.logger.warning(
+                    "Failed to delete S3 file s3://%s/%s: %s",
+                    s3_info.s3_bucket,
+                    part_path,
+                    str(exc),
+                )
 
     def load_from_s3(  # pylint: disable=too-many-locals
         self,
@@ -238,7 +226,7 @@ class FastSyncLoader:  # pylint: disable=too-few-public-methods,too-many-instanc
             "Fast sync: Loading %s rows from s3://%s/%s into '%s'",
             s3_info.rows_uploaded,
             s3_info.s3_bucket,
-            s3_info.s3_path,
+            s3_info.base_s3_path,
             stage_table,
         )
 

--- a/target_redshift/fast_sync/loader.py
+++ b/target_redshift/fast_sync/loader.py
@@ -27,6 +27,7 @@ class FastSyncS3Info:
     bytes_uploaded: int = 0
     time_extracted: str = ""
     pyarrow_schema: Optional[pa.Schema] = None
+    partition_column: Optional[str] = None
 
     @classmethod
     def from_message(cls, message: Dict[str, Any]) -> "FastSyncS3Info":
@@ -51,6 +52,7 @@ class FastSyncS3Info:
             bytes_uploaded=message.get("bytes_uploaded", 0),
             time_extracted=message.get("time_extracted", ""),
             pyarrow_schema=pyarrow_schema,
+            partition_column=message.get("partition_column"),
         )
 
     @property

--- a/target_redshift/fast_sync/loader.py
+++ b/target_redshift/fast_sync/loader.py
@@ -4,11 +4,12 @@ Fast Sync Loader for target-redshift
 This module handles loading data from S3 into Redshift using the fast sync strategy.
 It extracts data loading logic from DbSync to provide a cleaner separation of concerns.
 """
-
+import base64
 import json
 from dataclasses import dataclass
-from typing import Dict, List, Tuple, Any
+from typing import Dict, List, Tuple, Any, Optional
 import psycopg2.extras
+import pyarrow as pa
 
 from target_redshift.db_sync import safe_column_name
 
@@ -26,10 +27,21 @@ class FastSyncS3Info:
     rows_uploaded: int = 0
     bytes_uploaded: int = 0
     time_extracted: str = ""
+    pyarrow_schema: Optional[pa.Schema] = None
 
     @classmethod
     def from_message(cls, message: Dict[str, Any]) -> "FastSyncS3Info":
         """Create FastSyncS3Info from a message dictionary."""
+
+        pyarrow_schema = None
+        if "pyarrow_schema" in message:
+            # Convert base64-encoded serialized PyArrow schema back to PyArrow schema
+            # The schema is stored as base64-encoded serialized bytes in the message
+            schema_data = message["pyarrow_schema"]
+            # Decode base64 string to bytes and deserialize to PyArrow schema
+            schema_bytes = base64.b64decode(schema_data.encode('utf-8'))
+            pyarrow_schema = pa.ipc.read_schema(pa.py_buffer(schema_bytes))
+
         return cls(
             s3_bucket=message["s3_bucket"],
             s3_path=message["s3_path"],
@@ -40,6 +52,7 @@ class FastSyncS3Info:
             rows_uploaded=message.get("rows_uploaded", 0),
             bytes_uploaded=message.get("bytes_uploaded", 0),
             time_extracted=message.get("time_extracted", ""),
+            pyarrow_schema=pyarrow_schema,
         )
 
 

--- a/tests/unit/test_fast_sync_handler.py
+++ b/tests/unit/test_fast_sync_handler.py
@@ -175,7 +175,7 @@ class TestFastSyncHandler:
         db = MagicMock()
         message = self._create_valid_message(rows_uploaded=100)
 
-        fast_sync_handler.load_from_s3("test_stream", message, db)
+        fast_sync_handler.load_from_s3("test_stream", message, db, iceberg_enabled=False)
 
         mock_loader_class.assert_called_once_with(db)
         # Verify load_from_s3 was called with FastSyncS3Info dataclass
@@ -201,7 +201,9 @@ class TestFastSyncHandler:
         message = self._create_valid_message(replication_method="INCREMENTAL")
 
         with pytest.raises(Exception, match="Load failed"):
-            fast_sync_handler.load_from_s3("test_stream", message, db)
+            fast_sync_handler.load_from_s3(
+                "test_stream", message, db, iceberg_enabled=False
+            )
 
         # Verify load_from_s3 was called
         mock_loader.load_from_s3.assert_called_once()
@@ -214,7 +216,9 @@ class TestFastSyncHandler:
         db = MagicMock()
         message = self._create_valid_message(s3_region="us-west-2", files_uploaded=2)
 
-        fast_sync_handler.load_from_s3("test_stream", message, db)
+        fast_sync_handler.load_from_s3(
+            "test_stream", message, db, iceberg_enabled=False
+        )
 
         # Verify load_from_s3 was called with FastSyncS3Info dataclass
         assert mock_loader.load_from_s3.call_count == 1
@@ -229,10 +233,32 @@ class TestFastSyncHandler:
         assert s3_info.files_uploaded == 2
         assert s3_info.replication_method == "FULL_TABLE"
 
+    @patch("target_redshift.fast_sync.handler.FastSyncIcebergLoader")
+    def test_load_from_s3_iceberg_enabled_uses_iceberg_loader(self, mock_iceberg_class):
+        """Test that when iceberg_enabled=True, FastSyncIcebergLoader is used"""
+        mock_iceberg_loader = MagicMock()
+        mock_iceberg_class.return_value = mock_iceberg_loader
+
+        db = MagicMock()
+        message = self._create_valid_message(rows_uploaded=50)
+
+        fast_sync_handler.load_from_s3(
+            "test_schema-test_table", message, db, iceberg_enabled=True
+        )
+
+        mock_iceberg_class.assert_called_once()
+        call_args = mock_iceberg_class.call_args[0]
+        assert call_args[0] is db
+        assert isinstance(call_args[1], FastSyncS3Info)
+        assert call_args[1].s3_bucket == "test-bucket"
+        assert call_args[1].s3_path == "test/path/data.csv"
+        assert call_args[1].rows_uploaded == 50
+        mock_iceberg_loader.load_from_s3.assert_called_once_with()
+
     def test_flush_operations_empty_queue(self):
         """Test flush_operations with empty queue"""
         # Should return early without any processing
-        fast_sync_handler.flush_operations({}, {}, 4, 16)
+        fast_sync_handler.flush_operations({}, {}, 4, 16, False)
 
     @patch("target_redshift.fast_sync.handler.Parallel")
     def test_flush_operations_with_parallelism(self, mock_parallel_class):
@@ -242,7 +268,9 @@ class TestFastSyncHandler:
 
         fast_sync_queue, stream_to_sync = self._create_fast_sync_queue_and_streams(2)
 
-        fast_sync_handler.flush_operations(fast_sync_queue, stream_to_sync, 2, 16)
+        fast_sync_handler.flush_operations(
+            fast_sync_queue, stream_to_sync, 2, 16, iceberg_enabled=False
+        )
 
         # Verify Parallel was instantiated and called
         mock_parallel_class.assert_called_once()
@@ -255,7 +283,9 @@ class TestFastSyncHandler:
         fast_sync_queue, stream_to_sync = self._create_fast_sync_queue_and_streams(3)
 
         # parallelism=0 should use min(n_streams, max_parallelism)
-        fast_sync_handler.flush_operations(fast_sync_queue, stream_to_sync, 0, 2)
+        fast_sync_handler.flush_operations(
+            fast_sync_queue, stream_to_sync, 0, 2, iceberg_enabled=False
+        )
 
         # Verify parallel processing was invoked
         mock_parallel.assert_called_once()

--- a/tests/unit/test_fast_sync_handler.py
+++ b/tests/unit/test_fast_sync_handler.py
@@ -44,9 +44,8 @@ class TestFastSyncHandler:
         """Helper to create a valid FAST_SYNC_RDS_S3_INFO message"""
         message = {
             "s3_bucket": "test-bucket",
-            "s3_path": "test/path/data.csv",
+            "s3_paths": ["test/path/data.csv"],
             "s3_region": "us-east-1",
-            "files_uploaded": 1,
             "replication_method": "FULL_TABLE",
         }
         message.update(overrides)
@@ -130,20 +129,14 @@ class TestFastSyncHandler:
             "s3_bucket", "missing required fields: s3_bucket"
         )
 
-    def test_validate_and_extract_message_missing_s3_path(self):
-        """Test validation fails when s3_path is missing"""
-        self._test_validate_missing_field("s3_path", "missing required fields: s3_path")
+    def test_validate_and_extract_message_missing_s3_paths(self):
+        """Test validation fails when s3_paths is missing"""
+        self._test_validate_missing_field("s3_paths", "missing required fields: s3_paths")
 
     def test_validate_and_extract_message_missing_s3_region(self):
         """Test validation fails when s3_region is missing"""
         self._test_validate_missing_field(
             "s3_region", "missing required fields: s3_region"
-        )
-
-    def test_validate_and_extract_message_missing_files_uploaded(self):
-        """Test validation fails when files_uploaded is missing"""
-        self._test_validate_missing_field(
-            "files_uploaded", "missing required fields: files_uploaded"
         )
 
     def test_validate_and_extract_message_missing_replication_method(self):
@@ -156,7 +149,7 @@ class TestFastSyncHandler:
         """Test validation fails when multiple required fields are missing"""
         message = {
             "s3_bucket": "test-bucket"
-            # Missing: s3_path, s3_region, files_uploaded, replication_method
+            # Missing: s3_paths, s3_region, replication_method
             # Note: rows_uploaded is optional
         }
         stream_id = "test_schema-test_table"
@@ -185,10 +178,9 @@ class TestFastSyncHandler:
         s3_info = call_args[0]
         assert isinstance(s3_info, FastSyncS3Info)
         assert s3_info.s3_bucket == "test-bucket"
-        assert s3_info.s3_path == "test/path/data.csv"
+        assert s3_info.s3_paths == ["test/path/data.csv"]
         assert s3_info.s3_region == "us-east-1"
         assert s3_info.rows_uploaded == 100
-        assert s3_info.files_uploaded == 1
         assert s3_info.replication_method == "FULL_TABLE"
 
     @patch("target_redshift.fast_sync.handler.FastSyncLoader")
@@ -214,7 +206,7 @@ class TestFastSyncHandler:
         mock_loader = self._create_mock_loader(mock_loader_class)
 
         db = MagicMock()
-        message = self._create_valid_message(s3_region="us-west-2", files_uploaded=2)
+        message = self._create_valid_message(s3_region="us-west-2")
 
         fast_sync_handler.load_from_s3(
             "test_stream", message, db, iceberg_enabled=False
@@ -227,10 +219,9 @@ class TestFastSyncHandler:
         s3_info = call_args[0]
         assert isinstance(s3_info, FastSyncS3Info)
         assert s3_info.s3_bucket == "test-bucket"
-        assert s3_info.s3_path == "test/path/data.csv"
+        assert s3_info.s3_paths == ["test/path/data.csv"]
         assert s3_info.s3_region == "us-west-2"
         assert s3_info.rows_uploaded == 0  # Default value when not provided
-        assert s3_info.files_uploaded == 2
         assert s3_info.replication_method == "FULL_TABLE"
 
     @patch("target_redshift.fast_sync.handler.FastSyncIcebergLoader")
@@ -251,7 +242,7 @@ class TestFastSyncHandler:
         assert call_args[0] is db
         assert isinstance(call_args[1], FastSyncS3Info)
         assert call_args[1].s3_bucket == "test-bucket"
-        assert call_args[1].s3_path == "test/path/data.csv"
+        assert call_args[1].s3_paths == ["test/path/data.csv"]
         assert call_args[1].rows_uploaded == 50
         mock_iceberg_loader.load_from_s3.assert_called_once_with()
 
@@ -297,9 +288,8 @@ class TestFastSyncHandler:
         """Test extract_operations_from_state with single fast_sync_s3_info"""
         s3_info = {
             "s3_bucket": "test-bucket",
-            "s3_path": "test/path/data.csv",
+            "s3_paths": ["test/path/data.csv"],
             "s3_region": "us-east-1",
-            "files_uploaded": 1,
             "replication_method": "FULL_TABLE",
             "rows_uploaded": 100,
         }

--- a/tests/unit/test_fast_sync_handler.py
+++ b/tests/unit/test_fast_sync_handler.py
@@ -238,12 +238,15 @@ class TestFastSyncHandler:
         )
 
         mock_iceberg_class.assert_called_once()
-        call_args = mock_iceberg_class.call_args[0]
-        assert call_args[0] is db
-        assert isinstance(call_args[1], FastSyncS3Info)
-        assert call_args[1].s3_bucket == "test-bucket"
-        assert call_args[1].s3_paths == ["test/path/data.csv"]
-        assert call_args[1].rows_uploaded == 50
+        call_kwargs = mock_iceberg_class.call_args[1]
+        assert call_kwargs["logger"] is db.logger
+        assert call_kwargs["stream"] == db.stream_schema_message["stream"]
+        assert call_kwargs["connection_config"] is db.connection_config
+        s3_info = call_kwargs["stream_s3_info"]
+        assert isinstance(s3_info, FastSyncS3Info)
+        assert s3_info.s3_bucket == "test-bucket"
+        assert s3_info.s3_paths == ["test/path/data.csv"]
+        assert s3_info.rows_uploaded == 50
         mock_iceberg_loader.load_from_s3.assert_called_once_with()
 
     def test_flush_operations_empty_queue(self):

--- a/tests/unit/test_fast_sync_iceberg_loader.py
+++ b/tests/unit/test_fast_sync_iceberg_loader.py
@@ -80,6 +80,22 @@ class TestFastSyncIcebergLoader:
             == "s3://my-bucket/iceberg/test_schema-test_table"
         )
 
+    def test_init_uses_partition_column_from_s3_info_when_provided(self):
+        """When FastSyncS3Info has partition_column set, loader uses it."""
+        s3_info_with_partition = FastSyncS3Info(
+            s3_bucket="my-bucket",
+            s3_paths=["fast_sync/export/path/data.parquet"],
+            s3_region="us-east-1",
+            replication_method="FULL_TABLE",
+            file_format="parquet",
+            rows_uploaded=100,
+            pyarrow_schema=self.source_schema,
+            partition_column="custom_ts",
+        )
+        db = self._create_db_sync()
+        loader = FastSyncIcebergLoader(db, s3_info_with_partition)
+        assert loader.partition_column == "custom_ts"
+
     @patch("target_redshift.fast_sync.iceberg.iceberg_loader.load_catalog")
     def test_load_from_s3_creates_table_and_adds_files(self, mock_load_catalog):
         """Test load_from_s3 when table does not exist: create table, sync schema, add_files"""

--- a/tests/unit/test_fast_sync_iceberg_loader.py
+++ b/tests/unit/test_fast_sync_iceberg_loader.py
@@ -153,34 +153,30 @@ class TestFastSyncIcebergLoader:
         assert mock_read_schema.call_args[0][0] == s3_file_path
 
     @patch("target_redshift.fast_sync.iceberg.iceberg_loader.load_catalog")
-    def test_load_iceberg_catalog_caches_catalog(self, mock_load_catalog):
-        """Test _load_iceberg_catalog is cached (load_catalog called once)"""
+    def testiceberg_catalog_caches_catalog(self, mock_load_catalog):
+        """Test iceberg_catalog is cached (load_catalog called once)"""
         mock_catalog = MagicMock()
         mock_load_catalog.return_value = mock_catalog
 
         db = self._create_db_sync()
         loader = FastSyncIcebergLoader(db, self.s3_info)
-        loader._source_schema = pa.schema([("id", pa.int64())])  # avoid pq.read_schema
-        loader._iceberg_table = MagicMock()  # avoid create_table path
 
-        cat1 = loader._load_iceberg_catalog()
-        cat2 = loader._load_iceberg_catalog()
+        cat1 = loader.iceberg_catalog
+        cat2 = loader.iceberg_catalog
 
         assert cat1 is cat2
         mock_load_catalog.assert_called_once()
 
     @patch("target_redshift.fast_sync.iceberg.iceberg_loader.load_catalog")
-    def test_load_iceberg_catalog_passes_glue_properties(self, mock_load_catalog):
-        """Test _load_iceberg_catalog passes Glue type and region to load_catalog"""
+    def testiceberg_catalog_passes_glue_properties(self, mock_load_catalog):
+        """Test iceberg_catalog passes Glue type and region to load_catalog"""
         mock_catalog = MagicMock()
         mock_load_catalog.return_value = mock_catalog
 
         db = self._create_db_sync()
         loader = FastSyncIcebergLoader(db, self.s3_info)
-        loader._source_schema = pa.schema([("id", pa.int64())])
-        loader._iceberg_table = MagicMock()
 
-        loader._load_iceberg_catalog()
+        _ = loader.iceberg_catalog
 
         mock_load_catalog.assert_called_once()
         assert mock_load_catalog.call_args[0][0] == "glue_catalog"
@@ -188,17 +184,23 @@ class TestFastSyncIcebergLoader:
         assert call_kw["type"] == "glue"
         assert call_kw["client.region"] == "us-east-1"
 
-    def test_sync_iceberg_table_data_calls_add_files(self):
-        """Test _sync_iceberg_table_data calls add_files with bucket/key path (prepends s3:// for PyIceberg)"""
+    @patch("target_redshift.fast_sync.iceberg.iceberg_loader.fs.S3FileSystem")
+    @patch(
+        "target_redshift.fast_sync.iceberg.iceberg_loader.pq.read_schema",
+        return_value=pa.schema([("id", pa.int64())]),
+    )
+    def test_sync_iceberg_table_calls_add_files(self, mock_read_schema, mock_s3fs):
+        """Test _sync_iceberg_table calls add_files with bucket/key path (prepends s3:// for PyIceberg)"""
         mock_table = MagicMock()
         mock_txt = MagicMock()
         mock_table.transaction.return_value.__enter__.return_value = mock_txt
         mock_table.transaction.return_value.__exit__.return_value = None
+        mock_table.schema.return_value.as_arrow.return_value.names = ["id"]
 
         db = self._create_db_sync()
         loader = FastSyncIcebergLoader(db, self.s3_info)
         s3_file_path = "my-bucket/path/file.parquet"
-        loader._sync_iceberg_table_data(mock_table, s3_file_path)
+        loader._sync_iceberg_table(mock_table, s3_file_path)
 
         mock_table.transaction.assert_called_once()
         mock_txt.add_files.assert_called_once_with(
@@ -206,8 +208,16 @@ class TestFastSyncIcebergLoader:
             check_duplicate_files=True,
         )
 
-    def test_sync_iceberg_table_schema_union_and_delete(self):
-        """Test _sync_iceberg_table_schema calls update_schema with union_by_name and delete_column"""
+    @patch("target_redshift.fast_sync.iceberg.iceberg_loader.fs.S3FileSystem")
+    @patch("target_redshift.fast_sync.iceberg.iceberg_loader.pq.read_schema")
+    def test_sync_iceberg_table_schema_union_and_delete(self, mock_read_schema, mock_s3fs):
+        """Test _sync_iceberg_table calls update_schema with union_by_name and delete_column"""
+        # Table has a,b; source has a,b,c -> union adds c; to_delete = source - table = {c}
+        source_schema = pa.schema(
+            [("a", pa.int64()), ("b", pa.string()), ("c", pa.int64())]
+        )
+        mock_read_schema.return_value = source_schema
+
         mock_table = MagicMock()
         mock_txt = MagicMock()
         mock_update = MagicMock()
@@ -215,16 +225,11 @@ class TestFastSyncIcebergLoader:
         mock_txt.update_schema.return_value.__exit__.return_value = None
         mock_table.transaction.return_value.__enter__.return_value = mock_txt
         mock_table.transaction.return_value.__exit__.return_value = None
-
-        # Table has a,b; source has a,b,c -> union adds c; to_delete = source - table = {c}
-        source_schema = pa.schema(
-            [("a", pa.int64()), ("b", pa.string()), ("c", pa.int64())]
-        )
         mock_table.schema.return_value.as_arrow.return_value.names = ["a", "b"]
 
         db = self._create_db_sync()
         loader = FastSyncIcebergLoader(db, self.s3_info)
-        loader._sync_iceberg_table_schema(mock_table, source_schema)
+        loader._sync_iceberg_table(mock_table, "my-bucket/fast_sync/export/path/data.parquet")
 
         mock_table.transaction.assert_called_once()
         mock_txt.update_schema.assert_called_once()
@@ -249,20 +254,12 @@ class TestFastSyncIcebergLoader:
         db = self._create_db_sync()
         loader = FastSyncIcebergLoader(db, self.s3_info)
 
-        with patch.object(
-            loader, "_sync_iceberg_table_schema"
-        ) as mock_sync_schema, patch.object(
-            loader, "_sync_iceberg_table_data"
-        ) as mock_sync_data:
+        with patch.object(loader, "_sync_iceberg_table") as mock_sync:
             loader.load_from_s3()
 
-        mock_sync_schema.assert_called_once()
-        assert mock_sync_schema.call_args[0][0] is mock_table
-        assert mock_sync_schema.call_args[0][1] == mock_read_schema.return_value
-
-        mock_sync_data.assert_called_once()
-        assert mock_sync_data.call_args[0][0] is mock_table
-        assert mock_sync_data.call_args[0][1] == "my-bucket/fast_sync/export/path/data.parquet"
+        mock_sync.assert_called_once_with(
+            mock_table, "my-bucket/fast_sync/export/path/data.parquet"
+        )
 
     @patch(
         "target_redshift.fast_sync.iceberg.iceberg_loader.pq.read_schema",
@@ -291,18 +288,13 @@ class TestFastSyncIcebergLoader:
         db = self._create_db_sync()
         loader = FastSyncIcebergLoader(db, s3_info_multi)
 
-        with patch.object(
-            loader, "_sync_iceberg_table_schema"
-        ) as mock_sync_schema, patch.object(
-            loader, "_sync_iceberg_table_data"
-        ) as mock_sync_data:
+        with patch.object(loader, "_sync_iceberg_table") as mock_sync:
             loader.load_from_s3()
 
-        assert mock_sync_schema.call_count == 2
-        assert mock_sync_data.call_count == 2
-        assert mock_sync_data.call_args_list[0][0][1] == (
+        assert mock_sync.call_count == 2
+        assert mock_sync.call_args_list[0][0][1] == (
             "my-bucket/fast_sync/export/path/data.parquet_part1"
         )
-        assert mock_sync_data.call_args_list[1][0][1] == (
+        assert mock_sync.call_args_list[1][0][1] == (
             "my-bucket/fast_sync/export/path/data.parquet_part2"
         )

--- a/tests/unit/test_fast_sync_iceberg_loader.py
+++ b/tests/unit/test_fast_sync_iceberg_loader.py
@@ -71,7 +71,7 @@ class TestFastSyncIcebergLoader:
         assert loader.partition_column == "_sdc_batched_at"
         assert loader.s3_region == "us-east-1"
         assert loader.s3_bucket == "my-bucket"
-        assert loader.source_s3_path == "my-bucket/fast_sync/export/path/data.parquet"
+        assert loader.source_s3_path == "s3://my-bucket/fast_sync/export/path/data.parquet"
         assert (
             loader.iceberg_table_location
             == "s3://my-bucket/iceberg/my_iceberg_db/test_schema_test_table"
@@ -262,8 +262,7 @@ class TestFastSyncIcebergLoader:
 
         mock_sync_data.assert_called_once()
         assert mock_sync_data.call_args[0][0] is mock_table
-        # Path from _iterate_source_s3_path is bucket/path (no s3:// prefix)
-        assert mock_sync_data.call_args[0][1] == "my-bucket/fast_sync/export/path/data.parquet"
+        assert mock_sync_data.call_args[0][1] == "s3://my-bucket/fast_sync/export/path/data.parquet"
 
     @patch(
         "target_redshift.fast_sync.iceberg.iceberg_loader.pq.read_schema",

--- a/tests/unit/test_fast_sync_iceberg_loader.py
+++ b/tests/unit/test_fast_sync_iceberg_loader.py
@@ -3,7 +3,6 @@ Unit tests for Fast Sync Iceberg loader in target-redshift
 """
 
 import pyarrow as pa
-import pytest
 from unittest.mock import MagicMock, patch
 
 from target_redshift import db_sync
@@ -48,9 +47,8 @@ class TestFastSyncIcebergLoader:
         )
         self.s3_info = FastSyncS3Info(
             s3_bucket="my-bucket",
-            s3_path="fast_sync/export/path/data.parquet",
+            s3_paths=["fast_sync/export/path/data.parquet"],
             s3_region="us-east-1",
-            files_uploaded=1,
             replication_method="FULL_TABLE",
             file_format="parquet",
             rows_uploaded=100,
@@ -76,7 +74,7 @@ class TestFastSyncIcebergLoader:
         assert loader.partition_column == "_sdc_batched_at"
         assert loader.s3_region == "us-east-1"
         assert loader.s3_bucket == "my-bucket"
-        assert loader.source_s3_path == "my-bucket/fast_sync/export/path/data.parquet"
+        assert loader.source_s3_paths == ["my-bucket/fast_sync/export/path/data.parquet"]
         assert (
             loader.iceberg_table_location
             == "s3://my-bucket/iceberg/test_schema-test_table"
@@ -125,7 +123,7 @@ class TestFastSyncIcebergLoader:
         mock_catalog.create_table.assert_not_called()
 
     @patch("target_redshift.fast_sync.iceberg.iceberg_loader.load_catalog")
-    def testiceberg_catalog_caches_catalog(self, mock_load_catalog):
+    def test_iceberg_catalog_caches_catalog(self, mock_load_catalog):
         """Test iceberg_catalog is cached (load_catalog called once)"""
         mock_catalog = MagicMock()
         mock_load_catalog.return_value = mock_catalog
@@ -140,7 +138,7 @@ class TestFastSyncIcebergLoader:
         mock_load_catalog.assert_called_once()
 
     @patch("target_redshift.fast_sync.iceberg.iceberg_loader.load_catalog")
-    def testiceberg_catalog_passes_glue_properties(self, mock_load_catalog):
+    def test_iceberg_catalog_passes_glue_properties(self, mock_load_catalog):
         """Test iceberg_catalog passes Glue type and region to load_catalog"""
         mock_catalog = MagicMock()
         mock_load_catalog.return_value = mock_catalog
@@ -182,9 +180,8 @@ class TestFastSyncIcebergLoader:
         )
         s3_info = FastSyncS3Info(
             s3_bucket="my-bucket",
-            s3_path="fast_sync/export/path/data.parquet",
+            s3_paths=["fast_sync/export/path/data.parquet"],
             s3_region="us-east-1",
-            files_uploaded=1,
             replication_method="FULL_TABLE",
             file_format="parquet",
             rows_uploaded=100,
@@ -232,7 +229,7 @@ class TestFastSyncIcebergLoader:
     def test_load_from_s3_multiple_files_calls_sync_once_with_all_paths(
         self, mock_load_catalog
     ):
-        """Test load_from_s3 with files_uploaded=2 calls _sync_iceberg_table once with both part paths"""
+        """Test load_from_s3 with multiple s3_paths calls _sync_iceberg_table once with all part paths"""
         mock_catalog = MagicMock()
         mock_table = MagicMock()
         mock_catalog.table_exists.return_value = True
@@ -241,9 +238,11 @@ class TestFastSyncIcebergLoader:
 
         s3_info_multi = FastSyncS3Info(
             s3_bucket="my-bucket",
-            s3_path="fast_sync/export/path/data.parquet",
+            s3_paths=[
+                "fast_sync/export/path/data.parquet_part1",
+                "fast_sync/export/path/data.parquet_part2",
+            ],
             s3_region="us-east-1",
-            files_uploaded=2,
             replication_method="FULL_TABLE",
             file_format="parquet",
             rows_uploaded=200,

--- a/tests/unit/test_fast_sync_iceberg_loader.py
+++ b/tests/unit/test_fast_sync_iceberg_loader.py
@@ -5,7 +5,6 @@ Unit tests for Fast Sync Iceberg loader in target-redshift
 import pyarrow as pa
 from unittest.mock import MagicMock, patch
 
-from target_redshift import db_sync
 from target_redshift.fast_sync.loader import FastSyncS3Info
 from target_redshift.fast_sync.iceberg.iceberg_loader import (
     FastSyncIcebergLoader,
@@ -17,31 +16,6 @@ class TestFastSyncIcebergLoader:
 
     def setup_method(self):
         """Set up test fixtures"""
-        self.config = {
-            "host": "test-host.redshift.amazonaws.com",
-            "port": 5439,
-            "user": "test_user",
-            "password": "test_password",
-            "dbname": "test_db",
-            "aws_access_key_id": "test_key",
-            "aws_secret_access_key": "test_secret",
-            "s3_bucket": "my-bucket",
-            "default_target_schema": "test_schema",
-            "iceberg_catalog_name": "glue_catalog",
-            "iceberg_namespace": "my_iceberg_db",
-            "iceberg_s3_prefix": "iceberg",
-        }
-        self.stream_schema_message = {
-            "stream": "test_schema-test_table",
-            "schema": {
-                "properties": {
-                    "id": {"type": ["null", "integer"]},
-                    "name": {"type": ["null", "string"]},
-                    "_sdc_batched_at": {"type": ["null", "string"], "format": "date-time"},
-                }
-            },
-            "key_properties": ["id"],
-        }
         self.source_schema = pa.schema(
             [("id", pa.int64()), ("name", pa.string()), ("_sdc_batched_at", pa.timestamp("us"))]
         )
@@ -55,17 +29,24 @@ class TestFastSyncIcebergLoader:
             pyarrow_schema=self.source_schema,
         )
 
-    def _create_db_sync(self, config=None, schema=None):
-        """Create DbSync with optional overrides"""
-        return db_sync.DbSync(
-            config or self.config,
-            schema or self.stream_schema_message,
+    def _create_loader(self, s3_info=None):
+        connection_config = {
+            "aws_access_key_id": "test_key",
+            "aws_secret_access_key": "test_secret",
+            "iceberg_catalog_name": "glue_catalog",
+            "iceberg_namespace": "my_iceberg_db",
+            "iceberg_s3_prefix": "iceberg",
+        }
+        return FastSyncIcebergLoader(
+            logger=MagicMock(),
+            stream="test_schema-test_table",
+            connection_config=connection_config,
+            stream_s3_info=s3_info or self.s3_info,
         )
 
     def test_init_sets_attributes(self):
         """Test FastSyncIcebergLoader init sets catalog, namespace, table and paths"""
-        db = self._create_db_sync()
-        loader = FastSyncIcebergLoader(db, self.s3_info)
+        loader = self._create_loader()
 
         assert loader.catalog_name == "glue_catalog"
         assert loader.iceberg_namespace == "my_iceberg_db"
@@ -99,14 +80,13 @@ class TestFastSyncIcebergLoader:
     @patch("target_redshift.fast_sync.iceberg.iceberg_loader.load_catalog")
     def test_load_from_s3_creates_table_and_adds_files(self, mock_load_catalog):
         """Test load_from_s3 when table does not exist: create table, sync schema, add_files"""
-        db = self._create_db_sync()
         mock_catalog = MagicMock()
         mock_table = MagicMock()
         mock_catalog.table_exists.return_value = False
         mock_catalog.create_table.return_value = mock_table
         mock_load_catalog.return_value = mock_catalog
 
-        loader = FastSyncIcebergLoader(db, self.s3_info)
+        loader = self._create_loader()
         loader.load_from_s3()
 
         mock_catalog.create_namespace_if_not_exists.assert_called_once_with(
@@ -123,14 +103,13 @@ class TestFastSyncIcebergLoader:
     @patch("target_redshift.fast_sync.iceberg.iceberg_loader.load_catalog")
     def test_load_from_s3_existing_table_loads_and_syncs(self, mock_load_catalog):
         """Test load_from_s3 when table exists: load_table, no create_table"""
-        db = self._create_db_sync()
         mock_catalog = MagicMock()
         mock_table = MagicMock()
         mock_catalog.table_exists.return_value = True
         mock_catalog.load_table.return_value = mock_table
         mock_load_catalog.return_value = mock_catalog
 
-        loader = FastSyncIcebergLoader(db, self.s3_info)
+        loader = self._create_loader()
         loader.load_from_s3()
 
         mock_catalog.load_table.assert_called_once_with(
@@ -144,8 +123,7 @@ class TestFastSyncIcebergLoader:
         mock_catalog = MagicMock()
         mock_load_catalog.return_value = mock_catalog
 
-        db = self._create_db_sync()
-        loader = FastSyncIcebergLoader(db, self.s3_info)
+        loader = self._create_loader()
 
         cat1 = loader.iceberg_catalog
         cat2 = loader.iceberg_catalog
@@ -159,9 +137,7 @@ class TestFastSyncIcebergLoader:
         mock_catalog = MagicMock()
         mock_load_catalog.return_value = mock_catalog
 
-        db = self._create_db_sync()
-        loader = FastSyncIcebergLoader(db, self.s3_info)
-
+        loader = self._create_loader()
         _ = loader.iceberg_catalog
 
         mock_load_catalog.assert_called_once()
@@ -178,8 +154,7 @@ class TestFastSyncIcebergLoader:
         mock_table.transaction.return_value.__exit__.return_value = None
         mock_table.schema.return_value.as_arrow.return_value.names = ["id"]
 
-        db = self._create_db_sync()
-        loader = FastSyncIcebergLoader(db, self.s3_info)
+        loader = self._create_loader()
         loader._sync_iceberg_table(mock_table, ["my-bucket/path/file.parquet"])
 
         mock_table.transaction.assert_called_once()
@@ -213,8 +188,7 @@ class TestFastSyncIcebergLoader:
         mock_table.transaction.return_value.__exit__.return_value = None
         mock_table.schema.return_value.as_arrow.return_value.names = ["a", "b", "d"]
 
-        db = self._create_db_sync()
-        loader = FastSyncIcebergLoader(db, s3_info)
+        loader = self._create_loader(s3_info=s3_info)
         loader._sync_iceberg_table(mock_table, ["my-bucket/fast_sync/export/path/data.parquet"])
 
         mock_table.transaction.assert_called_once()
@@ -231,8 +205,7 @@ class TestFastSyncIcebergLoader:
         mock_catalog.load_table.return_value = mock_table
         mock_load_catalog.return_value = mock_catalog
 
-        db = self._create_db_sync()
-        loader = FastSyncIcebergLoader(db, self.s3_info)
+        loader = self._create_loader()
 
         with patch.object(loader, "_sync_iceberg_table") as mock_sync:
             loader.load_from_s3()
@@ -264,8 +237,7 @@ class TestFastSyncIcebergLoader:
             rows_uploaded=200,
             pyarrow_schema=self.source_schema,
         )
-        db = self._create_db_sync()
-        loader = FastSyncIcebergLoader(db, s3_info_multi)
+        loader = self._create_loader(s3_info=s3_info_multi)
 
         with patch.object(loader, "_sync_iceberg_table") as mock_sync:
             loader.load_from_s3()

--- a/tests/unit/test_fast_sync_iceberg_loader.py
+++ b/tests/unit/test_fast_sync_iceberg_loader.py
@@ -71,7 +71,7 @@ class TestFastSyncIcebergLoader:
         assert loader.partition_column == "_sdc_batched_at"
         assert loader.s3_region == "us-east-1"
         assert loader.s3_bucket == "my-bucket"
-        assert loader.source_s3_path == "s3://my-bucket/fast_sync/export/path/data.parquet"
+        assert loader.source_s3_path == "my-bucket/fast_sync/export/path/data.parquet"
         assert (
             loader.iceberg_table_location
             == "s3://my-bucket/iceberg/my_iceberg_db/test_schema_test_table"
@@ -189,7 +189,7 @@ class TestFastSyncIcebergLoader:
         assert call_kw["client.region"] == "us-east-1"
 
     def test_sync_iceberg_table_data_calls_add_files(self):
-        """Test _sync_iceberg_table_data calls add_files with single file path and check_duplicate_files"""
+        """Test _sync_iceberg_table_data calls add_files with bucket/key path (prepends s3:// for PyIceberg)"""
         mock_table = MagicMock()
         mock_txt = MagicMock()
         mock_table.transaction.return_value.__enter__.return_value = mock_txt
@@ -197,12 +197,12 @@ class TestFastSyncIcebergLoader:
 
         db = self._create_db_sync()
         loader = FastSyncIcebergLoader(db, self.s3_info)
-        s3_file_path = "s3://my-bucket/path/file.parquet"
+        s3_file_path = "my-bucket/path/file.parquet"
         loader._sync_iceberg_table_data(mock_table, s3_file_path)
 
         mock_table.transaction.assert_called_once()
         mock_txt.add_files.assert_called_once_with(
-            file_paths=[s3_file_path],
+            file_paths=["s3://my-bucket/path/file.parquet"],
             check_duplicate_files=True,
         )
 
@@ -262,7 +262,7 @@ class TestFastSyncIcebergLoader:
 
         mock_sync_data.assert_called_once()
         assert mock_sync_data.call_args[0][0] is mock_table
-        assert mock_sync_data.call_args[0][1] == "s3://my-bucket/fast_sync/export/path/data.parquet"
+        assert mock_sync_data.call_args[0][1] == "my-bucket/fast_sync/export/path/data.parquet"
 
     @patch(
         "target_redshift.fast_sync.iceberg.iceberg_loader.pq.read_schema",
@@ -301,8 +301,8 @@ class TestFastSyncIcebergLoader:
         assert mock_sync_schema.call_count == 2
         assert mock_sync_data.call_count == 2
         assert mock_sync_data.call_args_list[0][0][1] == (
-            "s3://my-bucket/fast_sync/export/path/data.parquet_part1"
+            "my-bucket/fast_sync/export/path/data.parquet_part1"
         )
         assert mock_sync_data.call_args_list[1][0][1] == (
-            "s3://my-bucket/fast_sync/export/path/data.parquet_part2"
+            "my-bucket/fast_sync/export/path/data.parquet_part2"
         )

--- a/tests/unit/test_fast_sync_iceberg_loader.py
+++ b/tests/unit/test_fast_sync_iceberg_loader.py
@@ -1,0 +1,261 @@
+"""
+Unit tests for Fast Sync Iceberg loader in target-redshift
+"""
+
+import pyarrow as pa
+import pytest
+from unittest.mock import MagicMock, patch
+
+from target_redshift import db_sync
+from target_redshift.fast_sync.loader import FastSyncS3Info
+from target_redshift.fast_sync.iceberg.iceberg_loader import (
+    FastSyncIcebergLoader,
+)
+
+
+class TestFastSyncIcebergLoader:
+    """Test cases for FastSyncIcebergLoader"""
+
+    def setup_method(self):
+        """Set up test fixtures"""
+        self.config = {
+            "host": "test-host.redshift.amazonaws.com",
+            "port": 5439,
+            "user": "test_user",
+            "password": "test_password",
+            "dbname": "test_db",
+            "aws_access_key_id": "test_key",
+            "aws_secret_access_key": "test_secret",
+            "s3_bucket": "my-bucket",
+            "default_target_schema": "test_schema",
+            "iceberg_catalog_name": "glue_catalog",
+            "iceberg_namespace": "my_iceberg_db",
+        }
+        self.stream_schema_message = {
+            "stream": "test_schema-test_table",
+            "schema": {
+                "properties": {
+                    "id": {"type": ["null", "integer"]},
+                    "name": {"type": ["null", "string"]},
+                    "_sdc_batched_at": {"type": ["null", "string"], "format": "date-time"},
+                }
+            },
+            "key_properties": ["id"],
+        }
+        self.s3_info = FastSyncS3Info(
+            s3_bucket="my-bucket",
+            s3_path="fast_sync/export/path/data.parquet",
+            s3_region="us-east-1",
+            files_uploaded=1,
+            replication_method="FULL_TABLE",
+            rows_uploaded=100,
+        )
+
+    def _create_db_sync(self, config=None, schema=None):
+        """Create DbSync with optional overrides"""
+        return db_sync.DbSync(
+            config or self.config,
+            schema or self.stream_schema_message,
+        )
+
+    def test_init_sets_attributes(self):
+        """Test FastSyncIcebergLoader init sets catalog, namespace, table and paths"""
+        db = self._create_db_sync()
+        loader = FastSyncIcebergLoader(db, self.s3_info)
+
+        assert loader.catalog_name == "glue_catalog"
+        assert loader.iceberg_namespace == "my_iceberg_db"
+        assert loader.iceberg_table == "test_schema_test_table"
+        assert loader.iceberg_table_identifier == "my_iceberg_db.test_schema_test_table"
+        assert loader.partition_column == "_sdc_batched_at"
+        assert loader.s3_region == "us-east-1"
+        assert loader.s3_bucket == "my-bucket"
+        assert loader.source_s3_path == "my-bucket/fast_sync/export/path/data.parquet"
+        assert (
+            loader.iceberg_table_location
+            == "s3://my-bucket/iceberg/my_iceberg_db/test_schema_test_table"
+        )
+
+    @patch(
+        "target_redshift.fast_sync.iceberg.iceberg_loader.pq.read_schema",
+        return_value=pa.schema([("id", pa.int64()), ("name", pa.string())]),
+    )
+    @patch("target_redshift.fast_sync.iceberg.iceberg_loader.load_catalog")
+    def test_load_from_s3_creates_table_and_adds_files(
+        self, mock_load_catalog, mock_read_schema
+    ):
+        """Test load_from_s3 when table does not exist: create table, sync schema, add_files"""
+        db = self._create_db_sync()
+        mock_catalog = MagicMock()
+        mock_table = MagicMock()
+        mock_catalog.table_exists.return_value = False
+        mock_catalog.create_table.return_value = mock_table
+        mock_load_catalog.return_value = mock_catalog
+
+        loader = FastSyncIcebergLoader(db, self.s3_info)
+        loader.load_from_s3()
+
+        mock_read_schema.assert_called_once()
+        mock_catalog.create_namespace_if_not_exists.assert_called_once_with(
+            "my_iceberg_db"
+        )
+        mock_catalog.table_exists.assert_called_once_with(
+            "my_iceberg_db.test_schema_test_table"
+        )
+        mock_catalog.create_table.assert_called_once()
+        call_kw = mock_catalog.create_table.call_args[1]
+        assert call_kw["identifier"] == "my_iceberg_db.test_schema_test_table"
+        assert call_kw["location"] == (
+            "s3://my-bucket/iceberg/my_iceberg_db/test_schema_test_table"
+        )
+
+    @patch(
+        "target_redshift.fast_sync.iceberg.iceberg_loader.pq.read_schema",
+        return_value=pa.schema([("id", pa.int64()), ("name", pa.string())]),
+    )
+    @patch("target_redshift.fast_sync.iceberg.iceberg_loader.load_catalog")
+    def test_load_from_s3_existing_table_loads_and_syncs(
+        self, mock_load_catalog, mock_read_schema
+    ):
+        """Test load_from_s3 when table exists: load_table, no create_table"""
+        db = self._create_db_sync()
+        mock_catalog = MagicMock()
+        mock_table = MagicMock()
+        mock_catalog.table_exists.return_value = True
+        mock_catalog.load_table.return_value = mock_table
+        mock_load_catalog.return_value = mock_catalog
+
+        loader = FastSyncIcebergLoader(db, self.s3_info)
+        loader.load_from_s3()
+
+        mock_catalog.load_table.assert_called_once_with(
+            "my_iceberg_db.test_schema_test_table"
+        )
+        mock_catalog.create_table.assert_not_called()
+
+    @patch("target_redshift.fast_sync.iceberg.iceberg_loader.fs.S3FileSystem")
+    @patch(
+        "target_redshift.fast_sync.iceberg.iceberg_loader.pq.read_schema",
+        return_value=pa.schema([("id", pa.int64())]),
+    )
+    def test_load_source_schema_caches_schema(self, mock_read_schema, mock_s3fs):
+        """Test _load_source_schema is cached (read_schema called once for two invocations)"""
+        db = self._create_db_sync()
+        loader = FastSyncIcebergLoader(db, self.s3_info)
+
+        schema1 = loader._load_source_schema()
+        schema2 = loader._load_source_schema()
+
+        assert schema1 is schema2
+        mock_read_schema.assert_called_once()
+
+    @patch("target_redshift.fast_sync.iceberg.iceberg_loader.load_catalog")
+    def test_load_iceberg_catalog_caches_catalog(self, mock_load_catalog):
+        """Test _load_iceberg_catalog is cached (load_catalog called once)"""
+        mock_catalog = MagicMock()
+        mock_load_catalog.return_value = mock_catalog
+
+        db = self._create_db_sync()
+        loader = FastSyncIcebergLoader(db, self.s3_info)
+        loader._source_schema = pa.schema([("id", pa.int64())])  # avoid pq.read_schema
+        loader._iceberg_table = MagicMock()  # avoid create_table path
+
+        cat1 = loader._load_iceberg_catalog()
+        cat2 = loader._load_iceberg_catalog()
+
+        assert cat1 is cat2
+        mock_load_catalog.assert_called_once()
+
+    @patch("target_redshift.fast_sync.iceberg.iceberg_loader.load_catalog")
+    def test_load_iceberg_catalog_passes_glue_properties(self, mock_load_catalog):
+        """Test _load_iceberg_catalog passes Glue type and region to load_catalog"""
+        mock_catalog = MagicMock()
+        mock_load_catalog.return_value = mock_catalog
+
+        db = self._create_db_sync()
+        loader = FastSyncIcebergLoader(db, self.s3_info)
+        loader._source_schema = pa.schema([("id", pa.int64())])
+        loader._iceberg_table = MagicMock()
+
+        loader._load_iceberg_catalog()
+
+        mock_load_catalog.assert_called_once()
+        assert mock_load_catalog.call_args[0][0] == "glue_catalog"
+        call_kw = mock_load_catalog.call_args[1]
+        assert call_kw["type"] == "glue"
+        assert call_kw["client.region"] == "us-east-1"
+
+    def test_sync_iceberg_table_data_calls_add_files(self):
+        """Test _sync_iceberg_table_data calls add_files with path and check_duplicate_files"""
+        mock_table = MagicMock()
+        mock_txt = MagicMock()
+        mock_table.transaction.return_value.__enter__.return_value = mock_txt
+        mock_table.transaction.return_value.__exit__.return_value = None
+
+        FastSyncIcebergLoader._sync_iceberg_table_data(
+            mock_table, "s3://my-bucket/path/file.parquet"
+        )
+
+        mock_table.transaction.assert_called_once()
+        mock_txt.add_files.assert_called_once_with(
+            file_paths=["s3://my-bucket/path/file.parquet"],
+            check_duplicate_files=True,
+        )
+
+    def test_sync_iceberg_table_schema_union_and_delete(self):
+        """Test _sync_iceberg_table_schema calls update_schema with union_by_name and delete_column"""
+        mock_table = MagicMock()
+        mock_txt = MagicMock()
+        mock_update = MagicMock()
+        mock_txt.update_schema.return_value.__enter__.return_value = mock_update
+        mock_txt.update_schema.return_value.__exit__.return_value = None
+        mock_table.transaction.return_value.__enter__.return_value = mock_txt
+        mock_table.transaction.return_value.__exit__.return_value = None
+
+        # Table has a,b; source has a,b,c -> union adds c; to_delete = source - table = {c}
+        # So we'd delete c after adding (current impl). Regardless, we just assert update_schema was used.
+        table_schema = pa.schema([("a", pa.int64()), ("b", pa.string())])
+        source_schema = pa.schema(
+            [("a", pa.int64()), ("b", pa.string()), ("c", pa.int64())]
+        )
+        mock_table.schema.return_value.as_arrow.return_value.names = ["a", "b"]
+
+        FastSyncIcebergLoader._sync_iceberg_table_schema(mock_table, source_schema)
+
+        mock_table.transaction.assert_called_once()
+        mock_txt.update_schema.assert_called_once()
+        mock_update.union_by_name.assert_called_once_with(source_schema)
+        mock_update.delete_column.assert_called()  # at least once for 'c' (in source not in table)
+
+    @patch(
+        "target_redshift.fast_sync.iceberg.iceberg_loader.pq.read_schema",
+        return_value=pa.schema([("id", pa.int64()), ("_sdc_batched_at", pa.timestamp("us"))]),
+    )
+    @patch("target_redshift.fast_sync.iceberg.iceberg_loader.load_catalog")
+    def test_load_from_s3_sync_schema_and_data_called(
+        self, mock_load_catalog, mock_read_schema
+    ):
+        """Test load_from_s3 calls schema sync and data sync with correct S3 path"""
+        mock_catalog = MagicMock()
+        mock_table = MagicMock()
+        mock_catalog.table_exists.return_value = True
+        mock_catalog.load_table.return_value = mock_table
+        mock_load_catalog.return_value = mock_catalog
+
+        db = self._create_db_sync()
+        loader = FastSyncIcebergLoader(db, self.s3_info)
+
+        with patch.object(
+            loader, "_sync_iceberg_table_schema"
+        ) as mock_sync_schema, patch.object(
+            loader, "_sync_iceberg_table_data"
+        ) as mock_sync_data:
+            loader.load_from_s3()
+
+        mock_sync_schema.assert_called_once()
+        assert mock_sync_schema.call_args[0][0] is mock_table
+        assert mock_sync_schema.call_args[0][1] == mock_read_schema.return_value
+
+        mock_sync_data.assert_called_once()
+        assert mock_sync_data.call_args[0][0] is mock_table
+        assert mock_sync_data.call_args[0][1] == "s3://my-bucket/fast_sync/export/path/data.parquet"

--- a/tests/unit/test_fast_sync_iceberg_loader.py
+++ b/tests/unit/test_fast_sync_iceberg_loader.py
@@ -79,7 +79,7 @@ class TestFastSyncIcebergLoader:
         assert loader.source_s3_path == "my-bucket/fast_sync/export/path/data.parquet"
         assert (
             loader.iceberg_table_location
-            == "s3://my-bucket/iceberg/my_iceberg_db/test_schema_test_table"
+            == "s3://my-bucket/iceberg/test_schema-test_table"
         )
 
     @patch("target_redshift.fast_sync.iceberg.iceberg_loader.load_catalog")
@@ -104,9 +104,7 @@ class TestFastSyncIcebergLoader:
         mock_catalog.create_table.assert_called_once()
         call_kw = mock_catalog.create_table.call_args[1]
         assert call_kw["identifier"] == "my_iceberg_db.test_schema_test_table"
-        assert call_kw["location"] == (
-            "s3://my-bucket/iceberg/my_iceberg_db/test_schema_test_table"
-        )
+        assert call_kw["location"] == "s3://my-bucket/iceberg/test_schema-test_table"
 
     @patch("target_redshift.fast_sync.iceberg.iceberg_loader.load_catalog")
     def test_load_from_s3_existing_table_loads_and_syncs(self, mock_load_catalog):

--- a/tests/unit/test_fast_sync_iceberg_loader.py
+++ b/tests/unit/test_fast_sync_iceberg_loader.py
@@ -30,6 +30,7 @@ class TestFastSyncIcebergLoader:
             "default_target_schema": "test_schema",
             "iceberg_catalog_name": "glue_catalog",
             "iceberg_namespace": "my_iceberg_db",
+            "iceberg_s3_prefix": "iceberg",
         }
         self.stream_schema_message = {
             "stream": "test_schema-test_table",
@@ -42,6 +43,9 @@ class TestFastSyncIcebergLoader:
             },
             "key_properties": ["id"],
         }
+        self.source_schema = pa.schema(
+            [("id", pa.int64()), ("name", pa.string()), ("_sdc_batched_at", pa.timestamp("us"))]
+        )
         self.s3_info = FastSyncS3Info(
             s3_bucket="my-bucket",
             s3_path="fast_sync/export/path/data.parquet",
@@ -50,6 +54,7 @@ class TestFastSyncIcebergLoader:
             replication_method="FULL_TABLE",
             file_format="parquet",
             rows_uploaded=100,
+            pyarrow_schema=self.source_schema,
         )
 
     def _create_db_sync(self, config=None, schema=None):
@@ -77,14 +82,8 @@ class TestFastSyncIcebergLoader:
             == "s3://my-bucket/iceberg/my_iceberg_db/test_schema_test_table"
         )
 
-    @patch(
-        "target_redshift.fast_sync.iceberg.iceberg_loader.pq.read_schema",
-        return_value=pa.schema([("id", pa.int64()), ("name", pa.string())]),
-    )
     @patch("target_redshift.fast_sync.iceberg.iceberg_loader.load_catalog")
-    def test_load_from_s3_creates_table_and_adds_files(
-        self, mock_load_catalog, mock_read_schema
-    ):
+    def test_load_from_s3_creates_table_and_adds_files(self, mock_load_catalog):
         """Test load_from_s3 when table does not exist: create table, sync schema, add_files"""
         db = self._create_db_sync()
         mock_catalog = MagicMock()
@@ -96,7 +95,6 @@ class TestFastSyncIcebergLoader:
         loader = FastSyncIcebergLoader(db, self.s3_info)
         loader.load_from_s3()
 
-        mock_read_schema.assert_called_once()
         mock_catalog.create_namespace_if_not_exists.assert_called_once_with(
             "my_iceberg_db"
         )
@@ -110,14 +108,8 @@ class TestFastSyncIcebergLoader:
             "s3://my-bucket/iceberg/my_iceberg_db/test_schema_test_table"
         )
 
-    @patch(
-        "target_redshift.fast_sync.iceberg.iceberg_loader.pq.read_schema",
-        return_value=pa.schema([("id", pa.int64()), ("name", pa.string())]),
-    )
     @patch("target_redshift.fast_sync.iceberg.iceberg_loader.load_catalog")
-    def test_load_from_s3_existing_table_loads_and_syncs(
-        self, mock_load_catalog, mock_read_schema
-    ):
+    def test_load_from_s3_existing_table_loads_and_syncs(self, mock_load_catalog):
         """Test load_from_s3 when table exists: load_table, no create_table"""
         db = self._create_db_sync()
         mock_catalog = MagicMock()
@@ -133,24 +125,6 @@ class TestFastSyncIcebergLoader:
             "my_iceberg_db.test_schema_test_table"
         )
         mock_catalog.create_table.assert_not_called()
-
-    @patch("target_redshift.fast_sync.iceberg.iceberg_loader.fs.S3FileSystem")
-    @patch(
-        "target_redshift.fast_sync.iceberg.iceberg_loader.pq.read_schema",
-        return_value=pa.schema([("id", pa.int64())]),
-    )
-    def test_load_source_schema_caches_schema(self, mock_read_schema, mock_s3fs):
-        """Test _load_source_schema is cached (read_schema called once for two invocations)"""
-        db = self._create_db_sync()
-        loader = FastSyncIcebergLoader(db, self.s3_info)
-        s3_file_path = "my-bucket/fast_sync/export/path/data.parquet"
-
-        schema1 = loader._load_source_schema(s3_file_path)
-        schema2 = loader._load_source_schema(s3_file_path)
-
-        assert schema1 is schema2
-        mock_read_schema.assert_called_once()
-        assert mock_read_schema.call_args[0][0] == s3_file_path
 
     @patch("target_redshift.fast_sync.iceberg.iceberg_loader.load_catalog")
     def testiceberg_catalog_caches_catalog(self, mock_load_catalog):
@@ -184,13 +158,8 @@ class TestFastSyncIcebergLoader:
         assert call_kw["type"] == "glue"
         assert call_kw["client.region"] == "us-east-1"
 
-    @patch("target_redshift.fast_sync.iceberg.iceberg_loader.fs.S3FileSystem")
-    @patch(
-        "target_redshift.fast_sync.iceberg.iceberg_loader.pq.read_schema",
-        return_value=pa.schema([("id", pa.int64())]),
-    )
-    def test_sync_iceberg_table_calls_add_files(self, mock_read_schema, mock_s3fs):
-        """Test _sync_iceberg_table calls add_files with bucket/key path (prepends s3:// for PyIceberg)"""
+    def test_sync_iceberg_table_calls_add_files(self):
+        """Test _sync_iceberg_table calls add_files with s3:// URIs for each file path"""
         mock_table = MagicMock()
         mock_txt = MagicMock()
         mock_table.transaction.return_value.__enter__.return_value = mock_txt
@@ -199,8 +168,7 @@ class TestFastSyncIcebergLoader:
 
         db = self._create_db_sync()
         loader = FastSyncIcebergLoader(db, self.s3_info)
-        s3_file_path = "my-bucket/path/file.parquet"
-        loader._sync_iceberg_table(mock_table, s3_file_path)
+        loader._sync_iceberg_table(mock_table, ["my-bucket/path/file.parquet"])
 
         mock_table.transaction.assert_called_once()
         mock_txt.add_files.assert_called_once_with(
@@ -208,15 +176,22 @@ class TestFastSyncIcebergLoader:
             check_duplicate_files=True,
         )
 
-    @patch("target_redshift.fast_sync.iceberg.iceberg_loader.fs.S3FileSystem")
-    @patch("target_redshift.fast_sync.iceberg.iceberg_loader.pq.read_schema")
-    def test_sync_iceberg_table_schema_union_and_delete(self, mock_read_schema, mock_s3fs):
-        """Test _sync_iceberg_table calls update_schema with union_by_name and delete_column"""
-        # Table has a,b; source has a,b,c -> union adds c; to_delete = source - table = {c}
+    def test_sync_iceberg_table_schema_union_and_delete(self):
+        """Test _sync_iceberg_table calls update_schema with union_by_name and deletes columns absent from source"""
+        # Table has a, b, d; source has a, b, c -> union adds c; to_delete = table - source = {d}
         source_schema = pa.schema(
             [("a", pa.int64()), ("b", pa.string()), ("c", pa.int64())]
         )
-        mock_read_schema.return_value = source_schema
+        s3_info = FastSyncS3Info(
+            s3_bucket="my-bucket",
+            s3_path="fast_sync/export/path/data.parquet",
+            s3_region="us-east-1",
+            files_uploaded=1,
+            replication_method="FULL_TABLE",
+            file_format="parquet",
+            rows_uploaded=100,
+            pyarrow_schema=source_schema,
+        )
 
         mock_table = MagicMock()
         mock_txt = MagicMock()
@@ -225,26 +200,20 @@ class TestFastSyncIcebergLoader:
         mock_txt.update_schema.return_value.__exit__.return_value = None
         mock_table.transaction.return_value.__enter__.return_value = mock_txt
         mock_table.transaction.return_value.__exit__.return_value = None
-        mock_table.schema.return_value.as_arrow.return_value.names = ["a", "b"]
+        mock_table.schema.return_value.as_arrow.return_value.names = ["a", "b", "d"]
 
         db = self._create_db_sync()
-        loader = FastSyncIcebergLoader(db, self.s3_info)
-        loader._sync_iceberg_table(mock_table, "my-bucket/fast_sync/export/path/data.parquet")
+        loader = FastSyncIcebergLoader(db, s3_info)
+        loader._sync_iceberg_table(mock_table, ["my-bucket/fast_sync/export/path/data.parquet"])
 
         mock_table.transaction.assert_called_once()
         mock_txt.update_schema.assert_called_once()
         mock_update.union_by_name.assert_called_once_with(source_schema)
-        mock_update.delete_column.assert_called()  # at least once for 'c' (in source not in table)
+        mock_update.delete_column.assert_called_once_with("d")
 
-    @patch(
-        "target_redshift.fast_sync.iceberg.iceberg_loader.pq.read_schema",
-        return_value=pa.schema([("id", pa.int64()), ("_sdc_batched_at", pa.timestamp("us"))]),
-    )
     @patch("target_redshift.fast_sync.iceberg.iceberg_loader.load_catalog")
-    def test_load_from_s3_sync_schema_and_data_called(
-        self, mock_load_catalog, mock_read_schema
-    ):
-        """Test load_from_s3 calls schema sync and data sync with correct S3 path"""
+    def test_load_from_s3_sync_schema_and_data_called(self, mock_load_catalog):
+        """Test load_from_s3 calls _sync_iceberg_table once with all file paths as a list"""
         mock_catalog = MagicMock()
         mock_table = MagicMock()
         mock_catalog.table_exists.return_value = True
@@ -258,18 +227,14 @@ class TestFastSyncIcebergLoader:
             loader.load_from_s3()
 
         mock_sync.assert_called_once_with(
-            mock_table, "my-bucket/fast_sync/export/path/data.parquet"
+            mock_table, ["my-bucket/fast_sync/export/path/data.parquet"]
         )
 
-    @patch(
-        "target_redshift.fast_sync.iceberg.iceberg_loader.pq.read_schema",
-        return_value=pa.schema([("id", pa.int64())]),
-    )
     @patch("target_redshift.fast_sync.iceberg.iceberg_loader.load_catalog")
-    def test_load_from_s3_multiple_files_calls_sync_data_per_file(
-        self, mock_load_catalog, mock_read_schema
+    def test_load_from_s3_multiple_files_calls_sync_once_with_all_paths(
+        self, mock_load_catalog
     ):
-        """Test load_from_s3 with files_uploaded=2 calls _sync_iceberg_table_data twice with part paths"""
+        """Test load_from_s3 with files_uploaded=2 calls _sync_iceberg_table once with both part paths"""
         mock_catalog = MagicMock()
         mock_table = MagicMock()
         mock_catalog.table_exists.return_value = True
@@ -284,6 +249,7 @@ class TestFastSyncIcebergLoader:
             replication_method="FULL_TABLE",
             file_format="parquet",
             rows_uploaded=200,
+            pyarrow_schema=self.source_schema,
         )
         db = self._create_db_sync()
         loader = FastSyncIcebergLoader(db, s3_info_multi)
@@ -291,10 +257,10 @@ class TestFastSyncIcebergLoader:
         with patch.object(loader, "_sync_iceberg_table") as mock_sync:
             loader.load_from_s3()
 
-        assert mock_sync.call_count == 2
-        assert mock_sync.call_args_list[0][0][1] == (
-            "my-bucket/fast_sync/export/path/data.parquet_part1"
-        )
-        assert mock_sync.call_args_list[1][0][1] == (
-            "my-bucket/fast_sync/export/path/data.parquet_part2"
+        mock_sync.assert_called_once_with(
+            mock_table,
+            [
+                "my-bucket/fast_sync/export/path/data.parquet_part1",
+                "my-bucket/fast_sync/export/path/data.parquet_part2",
+            ],
         )

--- a/tests/unit/test_fast_sync_iceberg_loader.py
+++ b/tests/unit/test_fast_sync_iceberg_loader.py
@@ -48,6 +48,7 @@ class TestFastSyncIcebergLoader:
             s3_region="us-east-1",
             files_uploaded=1,
             replication_method="FULL_TABLE",
+            file_format="parquet",
             rows_uploaded=100,
         )
 
@@ -142,12 +143,14 @@ class TestFastSyncIcebergLoader:
         """Test _load_source_schema is cached (read_schema called once for two invocations)"""
         db = self._create_db_sync()
         loader = FastSyncIcebergLoader(db, self.s3_info)
+        s3_file_path = "my-bucket/fast_sync/export/path/data.parquet"
 
-        schema1 = loader._load_source_schema()
-        schema2 = loader._load_source_schema()
+        schema1 = loader._load_source_schema(s3_file_path)
+        schema2 = loader._load_source_schema(s3_file_path)
 
         assert schema1 is schema2
         mock_read_schema.assert_called_once()
+        assert mock_read_schema.call_args[0][0] == s3_file_path
 
     @patch("target_redshift.fast_sync.iceberg.iceberg_loader.load_catalog")
     def test_load_iceberg_catalog_caches_catalog(self, mock_load_catalog):
@@ -186,19 +189,20 @@ class TestFastSyncIcebergLoader:
         assert call_kw["client.region"] == "us-east-1"
 
     def test_sync_iceberg_table_data_calls_add_files(self):
-        """Test _sync_iceberg_table_data calls add_files with path and check_duplicate_files"""
+        """Test _sync_iceberg_table_data calls add_files with single file path and check_duplicate_files"""
         mock_table = MagicMock()
         mock_txt = MagicMock()
         mock_table.transaction.return_value.__enter__.return_value = mock_txt
         mock_table.transaction.return_value.__exit__.return_value = None
 
-        FastSyncIcebergLoader._sync_iceberg_table_data(
-            mock_table, "s3://my-bucket/path/file.parquet"
-        )
+        db = self._create_db_sync()
+        loader = FastSyncIcebergLoader(db, self.s3_info)
+        s3_file_path = "s3://my-bucket/path/file.parquet"
+        loader._sync_iceberg_table_data(mock_table, s3_file_path)
 
         mock_table.transaction.assert_called_once()
         mock_txt.add_files.assert_called_once_with(
-            file_paths=["s3://my-bucket/path/file.parquet"],
+            file_paths=[s3_file_path],
             check_duplicate_files=True,
         )
 
@@ -213,14 +217,14 @@ class TestFastSyncIcebergLoader:
         mock_table.transaction.return_value.__exit__.return_value = None
 
         # Table has a,b; source has a,b,c -> union adds c; to_delete = source - table = {c}
-        # So we'd delete c after adding (current impl). Regardless, we just assert update_schema was used.
-        table_schema = pa.schema([("a", pa.int64()), ("b", pa.string())])
         source_schema = pa.schema(
             [("a", pa.int64()), ("b", pa.string()), ("c", pa.int64())]
         )
         mock_table.schema.return_value.as_arrow.return_value.names = ["a", "b"]
 
-        FastSyncIcebergLoader._sync_iceberg_table_schema(mock_table, source_schema)
+        db = self._create_db_sync()
+        loader = FastSyncIcebergLoader(db, self.s3_info)
+        loader._sync_iceberg_table_schema(mock_table, source_schema)
 
         mock_table.transaction.assert_called_once()
         mock_txt.update_schema.assert_called_once()
@@ -258,4 +262,48 @@ class TestFastSyncIcebergLoader:
 
         mock_sync_data.assert_called_once()
         assert mock_sync_data.call_args[0][0] is mock_table
-        assert mock_sync_data.call_args[0][1] == "s3://my-bucket/fast_sync/export/path/data.parquet"
+        # Path from _iterate_source_s3_path is bucket/path (no s3:// prefix)
+        assert mock_sync_data.call_args[0][1] == "my-bucket/fast_sync/export/path/data.parquet"
+
+    @patch(
+        "target_redshift.fast_sync.iceberg.iceberg_loader.pq.read_schema",
+        return_value=pa.schema([("id", pa.int64())]),
+    )
+    @patch("target_redshift.fast_sync.iceberg.iceberg_loader.load_catalog")
+    def test_load_from_s3_multiple_files_calls_sync_data_per_file(
+        self, mock_load_catalog, mock_read_schema
+    ):
+        """Test load_from_s3 with files_uploaded=2 calls _sync_iceberg_table_data twice with part paths"""
+        mock_catalog = MagicMock()
+        mock_table = MagicMock()
+        mock_catalog.table_exists.return_value = True
+        mock_catalog.load_table.return_value = mock_table
+        mock_load_catalog.return_value = mock_catalog
+
+        s3_info_multi = FastSyncS3Info(
+            s3_bucket="my-bucket",
+            s3_path="fast_sync/export/path/data.parquet",
+            s3_region="us-east-1",
+            files_uploaded=2,
+            replication_method="FULL_TABLE",
+            file_format="parquet",
+            rows_uploaded=200,
+        )
+        db = self._create_db_sync()
+        loader = FastSyncIcebergLoader(db, s3_info_multi)
+
+        with patch.object(
+            loader, "_sync_iceberg_table_schema"
+        ) as mock_sync_schema, patch.object(
+            loader, "_sync_iceberg_table_data"
+        ) as mock_sync_data:
+            loader.load_from_s3()
+
+        assert mock_sync_schema.call_count == 2
+        assert mock_sync_data.call_count == 2
+        assert mock_sync_data.call_args_list[0][0][1] == (
+            "my-bucket/fast_sync/export/path/data.parquet_part1"
+        )
+        assert mock_sync_data.call_args_list[1][0][1] == (
+            "my-bucket/fast_sync/export/path/data.parquet_part2"
+        )

--- a/tests/unit/test_fast_sync_iceberg_loader.py
+++ b/tests/unit/test_fast_sync_iceberg_loader.py
@@ -301,8 +301,8 @@ class TestFastSyncIcebergLoader:
         assert mock_sync_schema.call_count == 2
         assert mock_sync_data.call_count == 2
         assert mock_sync_data.call_args_list[0][0][1] == (
-            "my-bucket/fast_sync/export/path/data.parquet_part1"
+            "s3://my-bucket/fast_sync/export/path/data.parquet_part1"
         )
         assert mock_sync_data.call_args_list[1][0][1] == (
-            "my-bucket/fast_sync/export/path/data.parquet_part2"
+            "s3://my-bucket/fast_sync/export/path/data.parquet_part2"
         )

--- a/tests/unit/test_fast_sync_iceberg_loader.py
+++ b/tests/unit/test_fast_sync_iceberg_loader.py
@@ -73,8 +73,7 @@ class TestFastSyncIcebergLoader:
             pyarrow_schema=self.source_schema,
             partition_column="custom_ts",
         )
-        db = self._create_db_sync()
-        loader = FastSyncIcebergLoader(db, s3_info_with_partition)
+        loader = self._create_loader(s3_info=s3_info_with_partition)
         assert loader.partition_column == "custom_ts"
 
     @patch("target_redshift.fast_sync.iceberg.iceberg_loader.load_catalog")

--- a/tests/unit/test_fast_sync_loader.py
+++ b/tests/unit/test_fast_sync_loader.py
@@ -115,18 +115,16 @@ class TestFastSyncLoader:
     def _create_s3_info(
         self,
         s3_bucket="source-bucket",
-        s3_path="test/path/data.csv",
+        s3_paths=None,
         s3_region="us-east-1",
         rows_uploaded=100,
-        files_uploaded=1,
         replication_method=None,
     ) -> FastSyncS3Info:
         """Helper to create FastSyncS3Info for tests"""
         return FastSyncS3Info(
             s3_bucket=s3_bucket,
-            s3_path=s3_path,
+            s3_paths=s3_paths or ["test/path/data.csv"],
             s3_region=s3_region,
-            files_uploaded=files_uploaded,
             replication_method=replication_method or "FULL_TABLE",
             rows_uploaded=rows_uploaded,
         )
@@ -141,10 +139,8 @@ class TestFastSyncLoader:
 
         s3_info = self._create_s3_info(
             s3_bucket="source-bucket",
-            s3_path="test/path/data.csv",
             s3_region="us-east-1",
             rows_uploaded=100,
-            files_uploaded=1,
         )
         loader.load_from_s3(s3_info)
 
@@ -173,10 +169,13 @@ class TestFastSyncLoader:
 
         s3_info = self._create_s3_info(
             s3_bucket="source-bucket",
-            s3_path="test/path/data.csv",
+            s3_paths=[
+                "test/path/data.csv",
+                "test/path/data.csv_part2",
+                "test/path/data.csv_part3",
+            ],
             s3_region="us-east-1",
             rows_uploaded=1000,
-            files_uploaded=3,
         )
         loader.load_from_s3(s3_info)
 
@@ -201,10 +200,8 @@ class TestFastSyncLoader:
 
         s3_info = self._create_s3_info(
             s3_bucket="source-bucket",
-            s3_path="test/path/data.csv",
             s3_region="us-east-1",
             rows_uploaded=100,
-            files_uploaded=1,
             replication_method="FULL_TABLE",
         )
         loader.load_from_s3(s3_info)
@@ -223,10 +220,8 @@ class TestFastSyncLoader:
 
         s3_info = self._create_s3_info(
             s3_bucket="source-bucket",
-            s3_path="test/path/data.csv",
             s3_region="us-east-1",
             rows_uploaded=100,
-            files_uploaded=1,
         )
         loader.load_from_s3(s3_info)
 
@@ -259,10 +254,8 @@ class TestFastSyncLoader:
 
         s3_info = self._create_s3_info(
             s3_bucket="source-bucket",
-            s3_path="test/path/data.csv",
             s3_region="us-east-1",
             rows_uploaded=100,
-            files_uploaded=1,
         )
         loader.load_from_s3(s3_info)
 
@@ -298,10 +291,8 @@ class TestFastSyncLoader:
         # Should not raise exception even if S3 cleanup fails
         s3_info = self._create_s3_info(
             s3_bucket="source-bucket",
-            s3_path="test/path/data.csv",
             s3_region="us-east-1",
             rows_uploaded=100,
-            files_uploaded=1,
         )
         loader.load_from_s3(s3_info)
 
@@ -323,10 +314,8 @@ class TestFastSyncLoader:
 
         s3_info = self._create_s3_info(
             s3_bucket="source-bucket",
-            s3_path="test/path/data.csv",
             s3_region="us-east-1",
             rows_uploaded=100,
-            files_uploaded=1,
         )
         loader.load_from_s3(s3_info)
 
@@ -350,10 +339,8 @@ class TestFastSyncLoader:
 
         s3_info = self._create_s3_info(
             s3_bucket="source-bucket",
-            s3_path="test/path/data.csv",
             s3_region="us-east-1",
             rows_uploaded=100,
-            files_uploaded=1,
         )
         loader.load_from_s3(s3_info)
 
@@ -399,10 +386,8 @@ class TestFastSyncLoader:
 
         s3_info = self._create_s3_info(
             s3_bucket="source-bucket",
-            s3_path="test/path/data.csv",
             s3_region="ap-southeast-1",
             rows_uploaded=10,
-            files_uploaded=1,
         )
         loader.load_from_s3(s3_info)
 
@@ -432,10 +417,8 @@ class TestFastSyncLoader:
 
         s3_info = self._create_s3_info(
             s3_bucket="source-bucket",
-            s3_path="test/path/data.csv",
             s3_region="us-east-1",  # Different region, but should be ignored
             rows_uploaded=10,
-            files_uploaded=1,
         )
         loader.load_from_s3(s3_info)
 
@@ -464,10 +447,8 @@ class TestFastSyncLoader:
 
         s3_info = self._create_s3_info(
             s3_bucket="source-bucket",
-            s3_path="test/path/data.csv",
             s3_region="us-east-1",
             rows_uploaded=100,
-            files_uploaded=1,
             replication_method="INCREMENTAL",
         )
         loader.load_from_s3(s3_info)
@@ -495,10 +476,8 @@ class TestFastSyncLoader:
 
         s3_info = self._create_s3_info(
             s3_bucket="source-bucket",
-            s3_path="test/path/data.csv",
             s3_region="us-east-1",
             rows_uploaded=100,
-            files_uploaded=1,
             replication_method="FULL_TABLE",
         )
         loader.load_from_s3(s3_info)
@@ -542,10 +521,8 @@ class TestFastSyncLoader:
 
         s3_info = self._create_s3_info(
             s3_bucket="source-bucket",
-            s3_path="test/path/data.csv",
             s3_region="us-east-1",
             rows_uploaded=100,
-            files_uploaded=1,
             replication_method="FULL_TABLE",
         )
         loader.load_from_s3(s3_info)

--- a/tests/unit/test_target_rs.py
+++ b/tests/unit/test_target_rs.py
@@ -53,9 +53,8 @@ class TestTargetRedshift:
         """Helper to create fast_sync_s3_info dictionary"""
         s3_info = {
             "s3_bucket": "test-bucket",
-            "s3_path": "test/path/data.csv",
+            "s3_paths": ["test/path/data.csv"],
             "s3_region": "us-east-1",
-            "files_uploaded": 1,
             "replication_method": "FULL_TABLE",
             "rows_uploaded": 100,
         }
@@ -178,19 +177,18 @@ class TestTargetRedshift:
         assert "test_schema-test_table" in operations
         operation = operations["test_schema-test_table"]
         assert operation["s3_bucket"] == "test-bucket"
-        assert operation["s3_path"] == "test/path/data.csv"
+        assert operation["s3_paths"] == ["test/path/data.csv"]
         assert operation["s3_region"] == "us-east-1"
-        assert operation["files_uploaded"] == 1
         assert operation["replication_method"] == "FULL_TABLE"
         assert operation["rows_uploaded"] == 100
 
     def test_extract_fast_sync_operations_from_state_multiple_operations(self):
         """Test extract_operations_from_state with multiple fast_sync_s3_info"""
         s3_info_1 = self._create_fast_sync_s3_info(
-            s3_path="test/path/data1.csv", rows_uploaded=100
+            s3_paths=["test/path/data1.csv"], rows_uploaded=100
         )
         s3_info_2 = self._create_fast_sync_s3_info(
-            s3_path="test/path/data2.csv",
+            s3_paths=["test/path/data2.csv"],
             rows_uploaded=200,
             replication_method="INCREMENTAL",
         )
@@ -294,9 +292,8 @@ class TestTargetRedshift:
         fast_sync_queue = {
             "test_schema-test_table": {
                 "s3_bucket": "test-bucket",
-                "s3_path": "test/path/data.csv",
+                "s3_paths": ["test/path/data.csv"],
                 "s3_region": "us-east-1",
-                "files_uploaded": 1,
                 "replication_method": "FULL_TABLE",
                 "rows_uploaded": 100,
             }
@@ -317,9 +314,8 @@ class TestTargetRedshift:
         fast_sync_queue = {
             "test_schema-test_table": {
                 "s3_bucket": "test-bucket",
-                "s3_path": "test/path/data.csv",
+                "s3_paths": ["test/path/data.csv"],
                 "s3_region": "us-east-1",
-                "files_uploaded": 1,
                 "replication_method": "FULL_TABLE",
             }
         }
@@ -340,14 +336,14 @@ class TestTargetRedshift:
                 "test_schema-test_table": {
                     "fast_sync_s3_info": {
                         "s3_bucket": "test-bucket",
-                        "s3_path": "test/path/data.csv",
+                        "s3_paths": ["test/path/data.csv"],
                     },
                     "other_bookmark": "value",
                 },
                 "test_schema-test_table2": {
                     "fast_sync_s3_info": {
                         "s3_bucket": "test-bucket",
-                        "s3_path": "test/path/data2.csv",
+                        "s3_paths": ["test/path/data2.csv"],
                     }
                 },
                 "test_schema-test_table3": {"other_bookmark": "value"},
@@ -419,9 +415,8 @@ class TestTargetRedshift:
                             "test_schema-test_table": {
                                 "fast_sync_s3_info": {
                                     "s3_bucket": "test-bucket",
-                                    "s3_path": "test/path/data.csv",
+                                    "s3_paths": ["test/path/data.csv"],
                                     "s3_region": "us-east-1",
-                                    "files_uploaded": 1,
                                     "replication_method": "FULL_TABLE",
                                     "rows_uploaded": 100,
                                 }

--- a/tests/unit/test_target_rs.py
+++ b/tests/unit/test_target_rs.py
@@ -307,7 +307,7 @@ class TestTargetRedshift:
         target_redshift.flush_fast_sync_queue(fast_sync_queue, stream_to_sync, config)
 
         mock_flush_operations.assert_called_once_with(
-            fast_sync_queue, stream_to_sync, 2, 16
+            fast_sync_queue, stream_to_sync, 2, 16, False
         )
         assert fast_sync_queue == {}
 
@@ -329,7 +329,7 @@ class TestTargetRedshift:
         target_redshift.flush_fast_sync_queue(fast_sync_queue, stream_to_sync, config)
 
         mock_flush_operations.assert_called_once_with(
-            fast_sync_queue, stream_to_sync, 0, 16
+            fast_sync_queue, stream_to_sync, 0, 16, False
         )
         assert fast_sync_queue == {}
 


### PR DESCRIPTION
[DATA-26502](https://kaligo.atlassian.net/browse/DATA-26502)

See also: https://github.com/Kaligo/pipelinewise-tap-postgres/pull/20

## Summary

Adds an **Iceberg destination** for Fast Sync. When `iceberg_enabled` is true, fast sync loads data into **Apache Iceberg** (Glue catalog + S3) instead of Redshift. Same tap and STATE flow; only the destination changes (e.g. for lakehouse use with Spark, Trino, Athena).

## What changes

- **Handler**: `load_from_s3(..., iceberg_enabled)` uses `FastSyncIcebergLoader` when true, else `FastSyncLoader`.
- **New loader** (`target_redshift.fast_sync.iceberg.iceberg_loader.FastSyncIcebergLoader`): reads Parquet schema from S3, ensures Glue namespace and table exist, evolves table schema to match source, then registers the source Parquet path with Iceberg `add_files()` (no data copy).
- **Config**: `iceberg_enabled`, `iceberg_catalog_name`, `iceberg_namespace`.


## Why `add_files` (not read + rewrite)

Source Parquet is already produced by the tap’s fast sync export (format, schema, partitioning). We only need the Iceberg catalog to point at those files. So we **register** them with `add_files()` instead of re-reading and rewriting. That avoids double I/O, extra storage, and keeps syncs fast. Schema evolution is done at metadata level (add/drop columns); existing files stay as-is.


## Schema evolution

We take the **Parquet schema** from the current fast sync S3 path as source of truth. In one transaction we: **add** columns from source with `union_by_name(source_schema)`, **drop** columns that are no longer in the source with `delete_column(...)`. Then we call `add_files(source_s3_path)` so the new export is part of the table.

## Flow (high level)

```mermaid
flowchart LR
    A[Tap exports to S3\n+ fast_sync_s3_info in STATE]
    B[Target: flush_fast_sync_queue]
    C{iceberg_enabled?}
    D[Redshift: COPY + merge]
    E[Iceberg: Glue + add_files]
    A --> B --> C
    C -->|No| D
    C -->|Yes| E
```

## Config

| Option                 | Description |
|------------------------|-------------|
| `iceberg_enabled`      | When true, fast sync → Iceberg (default: false). |
| `iceberg_catalog_name` | Glue catalog name (required if enabled). |
| `iceberg_namespace`    | Iceberg namespace / database (required if enabled). |

README updated with Fast Sync Iceberg section and unit tests added for the loader and handler (iceberg path).


[DATA-26502]: https://kaligo.atlassian.net/browse/DATA-26502?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ