### PR TITLE
fix(iceberg): use boto3 session for PyIceberg Glue cred refresh [DATA-33326]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ state.json
 *.db
 .DS_Store
 venv
+.venv
 env
 blog_old.md
 node_modules

--- a/target_redshift/db_sync.py
+++ b/target_redshift/db_sync.py
@@ -299,13 +299,21 @@ class DbSync:
                 aws_secret_access_key=aws_secret_access_key,
                 aws_session_token=aws_session_token,
             )
+
+            # Note: frozen credentials are not recommended for long-running processes
+            # as they won't auto-refresh, but for the short-lived process of loading a
+            # single stream it should be fine.
+            # For longer-running processes, it's recommended to use IAM Roles
+            # for Service Accounts (IRSA) (AWS_ROLE_ARN + AWS_WEB_IDENTITY_TOKEN_FILE),
+            # where boto3 is expected to refresh temporary credentials automatically.
+            credentials = aws_session.get_credentials().get_frozen_credentials()
+            self.connection_config["aws_access_key_id"] = credentials.access_key
+            self.connection_config["aws_secret_access_key"] = credentials.secret_key
+            self.connection_config["aws_session_token"] = credentials.token
         else:
             aws_session = boto3.session.Session(profile_name=aws_profile)
 
-        credentials = aws_session.get_credentials().get_frozen_credentials()
-        self.connection_config["aws_access_key_id"] = credentials.access_key
-        self.connection_config["aws_secret_access_key"] = credentials.secret_key
-        self.connection_config["aws_session_token"] = credentials.token
+        self.aws_session = aws_session
 
         self.s3 = aws_session.client("s3")
         self.skip_updates = self.connection_config.get("skip_updates", False)

--- a/target_redshift/fast_sync/handler.py
+++ b/target_redshift/fast_sync/handler.py
@@ -127,6 +127,7 @@ def load_from_s3(
                 stream=db_sync.stream_schema_message["stream"],
                 connection_config=db_sync.connection_config,
                 stream_s3_info=s3_info,
+                boto3_session=db_sync.aws_session,
             )
             loader.load_from_s3()
         else:

--- a/target_redshift/fast_sync/iceberg/iceberg_loader.py
+++ b/target_redshift/fast_sync/iceberg/iceberg_loader.py
@@ -1,7 +1,8 @@
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 from functools import cached_property
 import logging
 
+import boto3
 import pyarrow as pa
 from pyiceberg.catalog import load_catalog, Catalog
 from pyiceberg.table import Table
@@ -18,6 +19,7 @@ class FastSyncIcebergLoader:
         stream: str,
         connection_config: Dict[str, Any],
         stream_s3_info: FastSyncS3Info,
+        boto3_session: Optional[boto3.session.Session] = None,
     ):
 
         if stream_s3_info.file_format not in ("parquet", "orc", "avro"):
@@ -37,6 +39,7 @@ class FastSyncIcebergLoader:
         self.s3_region = stream_s3_info.s3_region
         self.s3_bucket = stream_s3_info.s3_bucket
         self.s3_keys = stream_s3_info.s3_paths
+        self.boto3_session = boto3_session
 
     @property
     def iceberg_table(self) -> str:
@@ -84,14 +87,23 @@ class FastSyncIcebergLoader:
     def iceberg_catalog(self) -> Catalog:
         """
         Load the iceberg catalog and create a namespace if it doesn't exist
+
+        When a boto3 Session is provided, build a Glue client with Session.client().
+        That is the supported boto3 API: the client uses the session's credential
+        provider for each request, so temporary creds (IRSA, assumed roles, etc.)
+        refresh instead of passing frozen keys from connection_config (used for COPY).
+
+        PyIceberg's GlueCatalog accepts this client directly; see GlueCatalog.__init__
+        (client=...) in apache/iceberg-python.
         """
-        catalog_props = {
+        catalog_props: Dict[str, Any] = {
             "type": "glue",
             "client.region": self.s3_region,
-            "client.access-key-id": self.connection_config.get("aws_access_key_id"),
-            "client.secret-access-key": self.connection_config.get("aws_secret_access_key"),
-            "client.session-token": self.connection_config.get("aws_session_token"),
         }
+        if self.boto3_session is not None:
+            catalog_props["client"] = self.boto3_session.client(
+                "glue", region_name=self.s3_region
+            )
         iceberg_catalog = load_catalog(self.catalog_name, **catalog_props)
         iceberg_catalog.create_namespace_if_not_exists(self.iceberg_namespace)
         return iceberg_catalog

--- a/tests/unit/test_fast_sync_handler.py
+++ b/tests/unit/test_fast_sync_handler.py
@@ -242,6 +242,7 @@ class TestFastSyncHandler:
         assert call_kwargs["logger"] is db.logger
         assert call_kwargs["stream"] == db.stream_schema_message["stream"]
         assert call_kwargs["connection_config"] is db.connection_config
+        assert call_kwargs["boto3_session"] is db.aws_session
         s3_info = call_kwargs["stream_s3_info"]
         assert isinstance(s3_info, FastSyncS3Info)
         assert s3_info.s3_bucket == "test-bucket"

--- a/tests/unit/test_fast_sync_iceberg_loader.py
+++ b/tests/unit/test_fast_sync_iceberg_loader.py
@@ -4,7 +4,6 @@ Unit tests for Fast Sync Iceberg loader in target-redshift
 
 import pyarrow as pa
 from unittest.mock import MagicMock, patch
-
 from target_redshift.fast_sync.loader import FastSyncS3Info
 from target_redshift.fast_sync.iceberg.iceberg_loader import (
     FastSyncIcebergLoader,
@@ -29,7 +28,7 @@ class TestFastSyncIcebergLoader:
             pyarrow_schema=self.source_schema,
         )
 
-    def _create_loader(self, s3_info=None):
+    def _create_loader(self, s3_info=None, boto3_session=None):
         connection_config = {
             "aws_access_key_id": "test_key",
             "aws_secret_access_key": "test_secret",
@@ -42,6 +41,7 @@ class TestFastSyncIcebergLoader:
             stream="test_schema-test_table",
             connection_config=connection_config,
             stream_s3_info=s3_info or self.s3_info,
+            boto3_session=boto3_session,
         )
 
     def test_init_sets_attributes(self):
@@ -132,18 +132,29 @@ class TestFastSyncIcebergLoader:
 
     @patch("target_redshift.fast_sync.iceberg.iceberg_loader.load_catalog")
     def test_iceberg_catalog_passes_glue_properties(self, mock_load_catalog):
-        """Test iceberg_catalog passes Glue type and region to load_catalog"""
+        """Test iceberg_catalog passes Glue type, region, and botocore session to load_catalog"""
         mock_catalog = MagicMock()
         mock_load_catalog.return_value = mock_catalog
 
-        loader = self._create_loader()
+        mock_glue_client = MagicMock()
+        mock_boto3_session = MagicMock()
+        mock_boto3_session.client.return_value = mock_glue_client
+
+        loader = self._create_loader(boto3_session=mock_boto3_session)
         _ = loader.iceberg_catalog
 
+        mock_boto3_session.client.assert_called_once_with(
+            "glue", region_name="us-east-1"
+        )
         mock_load_catalog.assert_called_once()
         assert mock_load_catalog.call_args[0][0] == "glue_catalog"
         call_kw = mock_load_catalog.call_args[1]
         assert call_kw["type"] == "glue"
         assert call_kw["client.region"] == "us-east-1"
+        assert call_kw["client"] is mock_glue_client
+        assert "client.access-key-id" not in call_kw
+        assert "client.secret-access-key" not in call_kw
+        assert "client.session-token" not in call_kw
 
     def test_sync_iceberg_table_calls_add_files(self):
         """Test _sync_iceberg_table calls add_files with s3:// URIs for each file path"""


### PR DESCRIPTION
https://kaligo.atlassian.net/browse/DATA-33326

## Summary
- Fast sync Iceberg failed against Glue with `ExpiredTokenException` when using refreshable AWS creds (e.g. IRSA), because PyIceberg was given frozen `client.access-key-id` / secret / session-token from `connection_config` when the instance is initialized, during long-running replication sessions (> 1 hour), the token expired when PyIceberg actually called requests to Glue.
- Glue catalog now reuses the same botocore session as the target (`DbSync.aws_session` → PyIceberg `botocore_session`) so credentials can refresh.
- Redshift `COPY` behaviour unchanged: credentials are still materialized into `connection_config` after building the boto3 session.

## Changes
- `db_sync.py`: store `self.aws_session`; keep freezing resolved credentials into `connection_config` for explicit-credentials `COPY`.
- `iceberg_loader.py`: optional `boto3_session`; pass the session to `load_catalog`; drop static Glue client key props.
- `handler.py`: pass `boto3_session=db_sync.aws_session` into `FastSyncIcebergLoader`.

## Test plan
- `./venv/bin/pytest tests/unit/test_fast_sync_iceberg_loader.py tests/unit/test_fast_sync_handler.py::TestFastSyncHandler::test_load_from_s3_iceberg_enabled_uses_iceberg_loader`
- Run fast sync with Iceberg on a cluster using `AWS_WEB_IDENTITY_TOKEN_FILE` / IRSA and confirm Glue operations no longer fail after token rotation.