### PR TITLE
[DATA-34304] feat: map JSON object/array to Redshift SUPER type

### DIFF
--- a/target_redshift/db_sync.py
+++ b/target_redshift/db_sync.py
@@ -62,8 +62,7 @@ def column_type(schema_property, with_length=True):
     if schema_property.get("maxLength", 0) > varchar_length:
         varchar_length = LONG_VARCHAR_LENGTH
     if "object" in property_type or "array" in property_type:
-        column_type = "character varying"
-        varchar_length = LONG_VARCHAR_LENGTH
+        column_type = "SUPER"
 
     # Every date-time JSON value is currently mapped to TIMESTAMP WITHOUT TIME ZONE
     #

--- a/tests/unit/test_db_sync.py
+++ b/tests/unit/test_db_sync.py
@@ -79,8 +79,8 @@ class TestTargetRedshift(object):
         assert mapper(json_int) == "numeric"
         assert mapper(json_int_or_str) == "character varying(65535)"
         assert mapper(json_bool) == "boolean"
-        assert mapper(json_obj) == "character varying(65535)"
-        assert mapper(json_arr) == "character varying(65535)"
+        assert mapper(json_obj) == "SUPER"
+        assert mapper(json_arr) == "SUPER"
 
     def test_stream_name_to_dict(self):
         """Test identifying catalog, schema and table names from fully qualified stream and table names"""


### PR DESCRIPTION
## [DATA-34304](https://kaligo.atlassian.net/browse/DATA-34304)

## Summary
- Map Singer `object` and `array` JSON schema types to Redshift `SUPER` type instead of `character varying(65535)`
- Enables native JSON querying on Redshift columns that store JSON data
- Updated unit tests to reflect the new type mapping

## Notes
- Existing tables with `character varying(65535)` columns will be versioned (renamed with timestamp suffix) and recreated as `SUPER` on the next sync run via `update_columns()`. Old data is preserved in the renamed column.
- Redshift COPY automatically parses JSON strings into SUPER values from CSV, so no changes to the COPY pipeline are needed.

## Test plan
- [x] Unit tests pass (`test_column_type_mapping` updated)
- [ ] Verify COPY from S3 correctly loads JSON into SUPER columns on a test Redshift cluster
- [ ] Verify `update_columns()` migration behavior on existing tables with VARCHAR JSON columns

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DATA-34304]: https://kaligo.atlassian.net/browse/DATA-34304?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ