### PR TITLE
feat(iceberg): allow empty file list in sync to create schema-only tables [DATA-33249]

### DIFF
--- a/target_redshift/fast_sync/handler.py
+++ b/target_redshift/fast_sync/handler.py
@@ -113,13 +113,20 @@ def load_from_s3(
     """Load data from S3 for a single stream (used for parallel processing)"""
     try:
         s3_info = FastSyncS3Info.from_message(message)
-        LOGGER.info(
-            "Processing %s for stream %s: s3://%s/%s",
-            FAST_SYNC_S3_INFO_KEY,
-            stream,
-            s3_info.s3_bucket,
-            s3_info.base_s3_path,
-        )
+        if s3_info.base_s3_path:
+            LOGGER.info(
+                "Processing %s for stream %s: s3://%s/%s",
+                FAST_SYNC_S3_INFO_KEY,
+                stream,
+                s3_info.s3_bucket,
+                s3_info.base_s3_path,
+            )
+        else:
+            LOGGER.info(
+                "Processing %s for stream %s: no S3 files",
+                FAST_SYNC_S3_INFO_KEY,
+                stream,
+            )
         if iceberg_enabled:
             LOGGER.info("Loading to iceberg for stream %s", stream)
             loader = FastSyncIcebergLoader(

--- a/target_redshift/fast_sync/iceberg/iceberg_loader.py
+++ b/target_redshift/fast_sync/iceberg/iceberg_loader.py
@@ -21,7 +21,6 @@ class FastSyncIcebergLoader:
         stream_s3_info: FastSyncS3Info,
         boto3_session: Optional[boto3.session.Session] = None,
     ):
-
         if stream_s3_info.file_format not in ("parquet", "orc", "avro"):
             raise ValueError(
                 f"Unsupported file format: {stream_s3_info.file_format}. Should be one of: parquet, orc, avro"
@@ -77,11 +76,15 @@ class FastSyncIcebergLoader:
 
                 for column_name in to_delete:
                     update.delete_column(column_name)
-            txt.add_files(
-                # s3_file_path is bucket/key (from source_s3_paths); add_files expects a full s3:// URI, so we prepend the prefix.
-                file_paths=[f"s3://{s3_file_path}" for s3_file_path in s3_file_paths],
-                check_duplicate_files=True,
-            )
+            if s3_file_paths:
+                txt.add_files(
+                    # s3_file_path is bucket/key (from source_s3_paths);
+                    # add_files expects a full s3:// URI, so we prepend the prefix.
+                    file_paths=[
+                        f"s3://{s3_file_path}" for s3_file_path in s3_file_paths
+                    ],
+                    check_duplicate_files=True,
+                )
 
     @cached_property
     def iceberg_catalog(self) -> Catalog:

--- a/target_redshift/fast_sync/loader.py
+++ b/target_redshift/fast_sync/loader.py
@@ -58,7 +58,8 @@ class FastSyncS3Info:
     @property
     def base_s3_path(self) -> str:
         # Expect first part is always the base path (common prefix for all files).
-        return self.s3_paths[0]
+        if self.s3_paths:
+            return self.s3_paths[0]
 
 
 class FastSyncLoader:  # pylint: disable=too-few-public-methods,too-many-instance-attributes
@@ -220,6 +221,13 @@ class FastSyncLoader:  # pylint: disable=too-few-public-methods,too-many-instanc
         Args:
             s3_info: FastSyncS3Info value object containing S3 information
         """
+        if s3_info.rows_uploaded == 0:
+            self.logger.info(
+                "No rows to load from S3 for stream %s, skipping COPY and merge",
+                self.stream_schema_message["stream"],
+            )
+            return
+
         stream = self.stream_schema_message["stream"]
         stage_table = self.db_sync.table_name(stream, is_stage=True)
         target_table = self.db_sync.table_name(stream, is_stage=False)

--- a/tests/unit/test_fast_sync_handler.py
+++ b/tests/unit/test_fast_sync_handler.py
@@ -131,7 +131,9 @@ class TestFastSyncHandler:
 
     def test_validate_and_extract_message_missing_s3_paths(self):
         """Test validation fails when s3_paths is missing"""
-        self._test_validate_missing_field("s3_paths", "missing required fields: s3_paths")
+        self._test_validate_missing_field(
+            "s3_paths", "missing required fields: s3_paths"
+        )
 
     def test_validate_and_extract_message_missing_s3_region(self):
         """Test validation fails when s3_region is missing"""
@@ -168,7 +170,9 @@ class TestFastSyncHandler:
         db = MagicMock()
         message = self._create_valid_message(rows_uploaded=100)
 
-        fast_sync_handler.load_from_s3("test_stream", message, db, iceberg_enabled=False)
+        fast_sync_handler.load_from_s3(
+            "test_stream", message, db, iceberg_enabled=False
+        )
 
         mock_loader_class.assert_called_once_with(db)
         # Verify load_from_s3 was called with FastSyncS3Info dataclass
@@ -223,6 +227,23 @@ class TestFastSyncHandler:
         assert s3_info.s3_region == "us-west-2"
         assert s3_info.rows_uploaded == 0  # Default value when not provided
         assert s3_info.replication_method == "FULL_TABLE"
+
+    @patch("target_redshift.fast_sync.handler.FastSyncLoader")
+    def test_load_from_s3_with_empty_s3_paths_does_not_raise(self, mock_loader_class):
+        """When s3_paths is empty, load_from_s3 should still dispatch without IndexError."""
+        mock_loader = self._create_mock_loader(mock_loader_class)
+
+        db = MagicMock()
+        message = self._create_valid_message(s3_paths=[], rows_uploaded=0)
+
+        fast_sync_handler.load_from_s3(
+            "test_stream", message, db, iceberg_enabled=False
+        )
+
+        assert mock_loader.load_from_s3.call_count == 1
+        s3_info = mock_loader.load_from_s3.call_args[0][0]
+        assert s3_info.s3_paths == []
+        assert s3_info.base_s3_path is None
 
     @patch("target_redshift.fast_sync.handler.FastSyncIcebergLoader")
     def test_load_from_s3_iceberg_enabled_uses_iceberg_loader(self, mock_iceberg_class):

--- a/tests/unit/test_fast_sync_iceberg_loader.py
+++ b/tests/unit/test_fast_sync_iceberg_loader.py
@@ -16,7 +16,11 @@ class TestFastSyncIcebergLoader:
     def setup_method(self):
         """Set up test fixtures"""
         self.source_schema = pa.schema(
-            [("id", pa.int64()), ("name", pa.string()), ("_sdc_batched_at", pa.timestamp("us"))]
+            [
+                ("id", pa.int64()),
+                ("name", pa.string()),
+                ("_sdc_batched_at", pa.timestamp("us")),
+            ]
         )
         self.s3_info = FastSyncS3Info(
             s3_bucket="my-bucket",
@@ -55,7 +59,9 @@ class TestFastSyncIcebergLoader:
         assert loader.partition_column == "_sdc_batched_at"
         assert loader.s3_region == "us-east-1"
         assert loader.s3_bucket == "my-bucket"
-        assert loader.source_s3_paths == ["my-bucket/fast_sync/export/path/data.parquet"]
+        assert loader.source_s3_paths == [
+            "my-bucket/fast_sync/export/path/data.parquet"
+        ]
         assert (
             loader.iceberg_table_location
             == "s3://my-bucket/iceberg/test_schema-test_table"
@@ -173,6 +179,24 @@ class TestFastSyncIcebergLoader:
             check_duplicate_files=True,
         )
 
+    def test_sync_iceberg_table_skips_add_files_when_no_paths(self):
+        """When s3_file_paths is empty, schema sync still runs but add_files is not called."""
+        mock_table = MagicMock()
+        mock_txt = MagicMock()
+        mock_update = MagicMock()
+        mock_txt.update_schema.return_value.__enter__.return_value = mock_update
+        mock_txt.update_schema.return_value.__exit__.return_value = None
+        mock_table.transaction.return_value.__enter__.return_value = mock_txt
+        mock_table.transaction.return_value.__exit__.return_value = None
+        mock_table.schema.return_value.as_arrow.return_value.names = ["id"]
+
+        loader = self._create_loader()
+        loader._sync_iceberg_table(mock_table, [])
+
+        mock_txt.update_schema.assert_called_once()
+        mock_update.union_by_name.assert_called_once_with(self.source_schema)
+        mock_txt.add_files.assert_not_called()
+
     def test_sync_iceberg_table_schema_union_and_delete(self):
         """Test _sync_iceberg_table calls update_schema with union_by_name and deletes columns absent from source"""
         # Table has a, b, d; source has a, b, c -> union adds c; to_delete = table - source = {d}
@@ -199,7 +223,9 @@ class TestFastSyncIcebergLoader:
         mock_table.schema.return_value.as_arrow.return_value.names = ["a", "b", "d"]
 
         loader = self._create_loader(s3_info=s3_info)
-        loader._sync_iceberg_table(mock_table, ["my-bucket/fast_sync/export/path/data.parquet"])
+        loader._sync_iceberg_table(
+            mock_table, ["my-bucket/fast_sync/export/path/data.parquet"]
+        )
 
         mock_table.transaction.assert_called_once()
         mock_txt.update_schema.assert_called_once()

--- a/tests/unit/test_fast_sync_loader.py
+++ b/tests/unit/test_fast_sync_loader.py
@@ -501,6 +501,30 @@ class TestFastSyncLoader:
 
     @patch("target_redshift.db_sync.boto3")
     @patch("target_redshift.db_sync.psycopg2.connect")
+    def test_fast_sync_skips_load_when_rows_uploaded_zero(
+        self, mock_connect, mock_boto3
+    ):
+        """When rows_uploaded is 0, load_from_s3 returns early without COPY, merge, or S3 cleanup."""
+        loader, mock_cursor, mock_s3_client = self._create_loader(
+            mock_connect=mock_connect, mock_boto3=mock_boto3
+        )
+
+        s3_info = self._create_s3_info(
+            s3_bucket="source-bucket",
+            s3_region="us-east-1",
+            rows_uploaded=0,
+        )
+        loader.load_from_s3(s3_info)
+
+        assert mock_cursor.execute.call_count == 0, (
+            "No SQL should be executed when rows_uploaded is 0"
+        )
+        assert mock_s3_client.delete_object.call_count == 0, (
+            "S3 files should not be deleted when rows_uploaded is 0"
+        )
+
+    @patch("target_redshift.db_sync.boto3")
+    @patch("target_redshift.db_sync.psycopg2.connect")
     def test_fast_sync_deletion_detection_no_primary_key_full_table(
         self, mock_connect, mock_boto3
     ):
@@ -532,3 +556,29 @@ class TestFastSyncLoader:
         assert len(deletion_calls) == 0, (
             "Deletion detection should NOT be executed without primary keys"
         )
+
+
+class TestFastSyncS3Info:
+    """Test cases for FastSyncS3Info value object"""
+
+    def test_base_s3_path_returns_first_path(self):
+        """base_s3_path returns the first entry of s3_paths."""
+        s3_info = FastSyncS3Info(
+            s3_bucket="my-bucket",
+            s3_paths=["a/b/data.csv", "a/b/data.csv_part2"],
+            s3_region="us-east-1",
+            replication_method="FULL_TABLE",
+            rows_uploaded=10,
+        )
+        assert s3_info.base_s3_path == "a/b/data.csv"
+
+    def test_base_s3_path_returns_none_when_paths_empty(self):
+        """base_s3_path returns None when s3_paths is empty (no IndexError)."""
+        s3_info = FastSyncS3Info(
+            s3_bucket="my-bucket",
+            s3_paths=[],
+            s3_region="us-east-1",
+            replication_method="FULL_TABLE",
+            rows_uploaded=0,
+        )
+        assert s3_info.base_s3_path is None


### PR DESCRIPTION
https://kaligo.atlassian.net/browse/DATA-33249

See also: https://github.com/Kaligo/pipelinewise-tap-postgres/pull/24

## Summary
- Allow passing an empty `s3_file_paths` list to `_sync_iceberg_table` so that Iceberg tables are always created and synced with a legit schema, even when there are no records from tap-postgres
- This aligns Iceberg target behavior with how target-redshift works — tables are always created with the correct schema to avoid breaking downstream data pipelines (bronze, silver, etc.) that expect these tables to exist

## Changes
- **`target_redshift/fast_sync/iceberg/iceberg_loader.py`**: Guard `txt.add_files(...)` with `if s3_file_paths:` so schema sync still runs but file ingestion is skipped when there are no files
- **`tests/unit/test_fast_sync_iceberg_loader.py`**: Add `test_sync_iceberg_table_skips_add_files_when_no_paths` to verify schema sync runs but `add_files` is not called when paths are empty

## Test plan
- [ ] Run `pytest tests/unit/test_fast_sync_iceberg_loader.py` — all tests pass including new empty-paths test
- [ ] Verify existing tests still pass (no regressions in schema sync or file-add behavior)