### PR TITLE
Revert "[DATA-34304] feat: map JSON object/array to Redshift SUPER type"

### DIFF
--- a/target_redshift/db_sync.py
+++ b/target_redshift/db_sync.py
@@ -62,7 +62,8 @@ def column_type(schema_property, with_length=True):
     if schema_property.get("maxLength", 0) > varchar_length:
         varchar_length = LONG_VARCHAR_LENGTH
     if "object" in property_type or "array" in property_type:
-        column_type = "SUPER"
+        column_type = "character varying"
+        varchar_length = LONG_VARCHAR_LENGTH
 
     # Every date-time JSON value is currently mapped to TIMESTAMP WITHOUT TIME ZONE
     #

--- a/tests/unit/test_db_sync.py
+++ b/tests/unit/test_db_sync.py
@@ -79,8 +79,8 @@ class TestTargetRedshift(object):
         assert mapper(json_int) == "numeric"
         assert mapper(json_int_or_str) == "character varying(65535)"
         assert mapper(json_bool) == "boolean"
-        assert mapper(json_obj) == "SUPER"
-        assert mapper(json_arr) == "SUPER"
+        assert mapper(json_obj) == "character varying(65535)"
+        assert mapper(json_arr) == "character varying(65535)"
 
     def test_stream_name_to_dict(self):
         """Test identifying catalog, schema and table names from fully qualified stream and table names"""


### PR DESCRIPTION
Reverts Kaligo/pipelinewise-target-redshift#13

Since it caused several issues on staging Redshift:
- It renamed the old VARCHAR column to random name like `payload_xxx`
- It created a new `SUPER` column like `payload` which is empty.

We need to revert this change to unblock staging and think of a good plan for this.