### PR TITLE
feat: process fast_sync STATE messages on arrival [DATA-33249]

### DIFF
--- a/target_redshift/__init__.py
+++ b/target_redshift/__init__.py
@@ -95,36 +95,17 @@ def emit_state(state):
         sys.stdout.flush()
 
 
-def flush_fast_sync_queue(
-    fast_sync_queue, stream_to_sync, config, flushed_state=None
-):  # pylint: disable=too-many-arguments
-    """Flush queued fast sync operations with parallelism from config and clear the queue.
-
-    Optionally cleans up fast_sync_s3_info from flushed_state bookmarks for processed streams.
-
-    Args:
-        fast_sync_queue: Dictionary of queued fast sync operations
-        stream_to_sync: Dictionary of stream sync instances
-        config: Configuration dictionary
-        flushed_state: Optional state dictionary to clean up fast_sync_s3_info from
-    """
-    if not fast_sync_queue:
-        return
-
-    parallelism = config.get("parallelism", DEFAULT_PARALLELISM)
-    max_parallelism = config.get("max_parallelism", DEFAULT_MAX_PARALLELISM)
-    iceberg_enabled = config.get("iceberg_enabled", False)
-    fast_sync_handler.flush_operations(
-        fast_sync_queue, stream_to_sync, parallelism, max_parallelism, iceberg_enabled
+def process_fast_sync_operations(
+    operations, stream_to_sync, config, flushed_state=None
+):
+    """Run fast_sync S3 loads and strip fast_sync_s3_info from flushed_state."""
+    fast_sync_handler.process_operations(
+        operations, stream_to_sync, config.get("iceberg_enabled", False)
     )
-
-    # Clean up fast_sync_s3_info from flushed_state if provided
     if flushed_state:
         fast_sync_handler.cleanup_fast_sync_s3_info_from_state(
-            flushed_state, fast_sync_queue.keys()
+            flushed_state, operations.keys()
         )
-
-    fast_sync_queue.clear()
 
 
 def get_schema_names_from_config(config):
@@ -166,9 +147,6 @@ def persist_lines(config, lines, table_cache=None) -> None:
     row_count = {}
     stream_to_sync = {}
     total_row_count = {}
-    fast_sync_queue = (
-        {}
-    )  # Queue for fast_sync_s3_info operations (extracted from STATE messages) to process in parallel
     batch_size_rows = config.get("batch_size_rows", DEFAULT_BATCH_SIZE_ROWS)
 
     # Loop over lines from stdin
@@ -328,18 +306,31 @@ def persist_lines(config, lines, table_cache=None) -> None:
             LOGGER.debug("ACTIVATE_VERSION message")
 
         elif t == "STATE":
-            LOGGER.debug("Setting state to {}".format(o["value"]))
             state = o["value"]
-
-            # Extract and queue fast sync operations from state bookmarks
-            operations = fast_sync_handler.extract_operations_from_state(
-                state, schemas, stream_to_sync
-            )
-            fast_sync_queue.update(operations)
+            LOGGER.debug("Setting state to {}".format(state))
 
             # Initially set flushed state
             if not flushed_state:
                 flushed_state = copy.deepcopy(state)
+
+            # Process fast_sync ops on arrival, not at end-of-input: the tap
+            # emits one STATE per windowed initial-load window, all keyed by
+            # the same stream_id, so a stream_id-keyed queue would overwrite
+            # all but the last window's fast_sync_s3_info.
+            operations = fast_sync_handler.extract_operations_from_state(
+                state, schemas, stream_to_sync
+            )
+            if operations:
+                if "bookmarks" not in flushed_state:
+                    flushed_state["bookmarks"] = {}
+                for stream_id in operations:
+                    flushed_state["bookmarks"][stream_id] = state["bookmarks"][
+                        stream_id
+                    ]
+                process_fast_sync_operations(
+                    operations, stream_to_sync, config, flushed_state
+                )
+                emit_state(copy.deepcopy(flushed_state))
 
         else:
             raise Exception(
@@ -353,9 +344,6 @@ def persist_lines(config, lines, table_cache=None) -> None:
         flushed_state = flush_streams(
             records_to_load, row_count, stream_to_sync, config, state, flushed_state
         )
-
-    # Process any remaining fast sync operations and clean up fast_sync_s3_info from flushed_state
-    flush_fast_sync_queue(fast_sync_queue, stream_to_sync, config, flushed_state)
 
     # emit latest state
     emit_state(copy.deepcopy(flushed_state))

--- a/target_redshift/fast_sync/handler.py
+++ b/target_redshift/fast_sync/handler.py
@@ -1,11 +1,10 @@
 """
 Fast Sync Handler for target-redshift
 
-This module handles fast_sync_s3_info embedded in STATE messages and processes them in parallel.
+This module handles fast_sync_s3_info embedded in STATE messages.
 """
 
 from typing import Dict, Any, Iterable
-from joblib import Parallel, delayed, parallel_backend
 from singer import get_logger
 from target_redshift.fast_sync.loader import FastSyncLoader, FastSyncS3Info
 from target_redshift.fast_sync.iceberg.iceberg_loader import FastSyncIcebergLoader
@@ -150,35 +149,23 @@ def load_from_s3(
         raise
 
 
-def flush_operations(
-    fast_sync_queue: Dict[str, Dict[str, Any]],
+def process_operations(
+    operations: Dict[str, Dict[str, Any]],
     stream_to_sync: Dict[str, Any],
-    parallelism: int,
-    max_parallelism: int,
     iceberg_enabled: bool,
 ) -> None:
-    """Process queued fast_sync_s3_info operations in parallel"""
-    if not fast_sync_queue:
-        return
+    """Process fast_sync_s3_info operations sequentially.
 
-    # Parallelism 0 means auto parallelism:
-    #
-    # Auto parallelism trying to flush streams efficiently with auto defined number
-    # of threads where the number of threads is the number of streams that need to
-    # be loaded but it's not greater than the value of max_parallelism
-    if parallelism == 0:
-        n_streams = len(fast_sync_queue)
-        parallelism = min(n_streams, max_parallelism)
-
-    with parallel_backend("threading", n_jobs=parallelism):
-        Parallel()(
-            delayed(load_from_s3)(
-                stream=stream,
-                message=message,
-                db_sync=stream_to_sync[stream],
-                iceberg_enabled=iceberg_enabled,
-            )
-            for stream, message in fast_sync_queue.items()
+    The target processes one fast_sync operation per STATE message (the tap
+    emits one STATE per windowed initial-load window), so ``operations``
+    holds at most one entry; no parallelism is needed.
+    """
+    for stream, message in operations.items():
+        load_from_s3(
+            stream=stream,
+            message=message,
+            db_sync=stream_to_sync[stream],
+            iceberg_enabled=iceberg_enabled,
         )
 
 

--- a/tests/unit/test_fast_sync_handler.py
+++ b/tests/unit/test_fast_sync_handler.py
@@ -271,43 +271,25 @@ class TestFastSyncHandler:
         assert s3_info.rows_uploaded == 50
         mock_iceberg_loader.load_from_s3.assert_called_once_with()
 
-    def test_flush_operations_empty_queue(self):
-        """Test flush_operations with empty queue"""
-        # Should return early without any processing
-        fast_sync_handler.flush_operations({}, {}, 4, 16, False)
+    def test_process_operations_empty(self):
+        """Empty operations is a no-op"""
+        fast_sync_handler.process_operations({}, {}, False)
 
-    @patch("target_redshift.fast_sync.handler.Parallel")
-    def test_flush_operations_with_parallelism(self, mock_parallel_class):
-        """Test flush_operations with explicit parallelism"""
-        mock_parallel_instance = MagicMock()
-        mock_parallel_class.return_value = mock_parallel_instance
+    @patch("target_redshift.fast_sync.handler.load_from_s3")
+    def test_process_operations_calls_load_from_s3(self, mock_load_from_s3):
+        """Each operation is dispatched to load_from_s3."""
+        operations, stream_to_sync = self._create_fast_sync_queue_and_streams(1)
 
-        fast_sync_queue, stream_to_sync = self._create_fast_sync_queue_and_streams(2)
-
-        fast_sync_handler.flush_operations(
-            fast_sync_queue, stream_to_sync, 2, 16, iceberg_enabled=False
+        fast_sync_handler.process_operations(
+            operations, stream_to_sync, iceberg_enabled=False
         )
 
-        # Verify Parallel was instantiated and called
-        mock_parallel_class.assert_called_once()
-        mock_parallel_instance.assert_called_once()
-
-    @patch("target_redshift.fast_sync.handler.parallel_backend")
-    @patch("target_redshift.fast_sync.handler.Parallel")
-    def test_flush_operations_auto_parallelism(self, mock_parallel, mock_backend):
-        """Test flush_operations with auto parallelism (parallelism=0)"""
-        fast_sync_queue, stream_to_sync = self._create_fast_sync_queue_and_streams(3)
-
-        # parallelism=0 should use min(n_streams, max_parallelism)
-        fast_sync_handler.flush_operations(
-            fast_sync_queue, stream_to_sync, 0, 2, iceberg_enabled=False
+        mock_load_from_s3.assert_called_once_with(
+            stream="stream1",
+            message=operations["stream1"],
+            db_sync=stream_to_sync["stream1"],
+            iceberg_enabled=False,
         )
-
-        # Verify parallel processing was invoked
-        mock_parallel.assert_called_once()
-        mock_backend.assert_called_once()
-        # Verify parallel_backend was called with threading backend
-        assert "threading" in str(mock_backend.call_args[0][0])
 
     def test_extract_operations_from_state_single_operation(self):
         """Test extract_operations_from_state with single fast_sync_s3_info"""

--- a/tests/unit/test_target_rs.py
+++ b/tests/unit/test_target_rs.py
@@ -275,59 +275,37 @@ class TestTargetRedshift:
                 state, self.schemas, stream_to_sync
             )
 
-    def test_flush_fast_sync_queue_empty_queue(self):
-        """Test flush_fast_sync_queue with empty queue"""
-        fast_sync_queue = {}
-        stream_to_sync = {}
-        config = {}
+    def test_process_fast_sync_operations_empty(self):
+        """Empty operations is a no-op"""
+        target_redshift.process_fast_sync_operations({}, {}, {})
 
-        # Should not raise any exception
-        target_redshift.flush_fast_sync_queue(fast_sync_queue, stream_to_sync, config)
-
-        assert fast_sync_queue == {}
-
-    @patch("target_redshift.fast_sync.handler.flush_operations")
-    def test_flush_fast_sync_queue_with_operations(self, mock_flush_operations):
-        """Test flush_fast_sync_queue with queued operations"""
-        fast_sync_queue = {
-            "test_schema-test_table": {
-                "s3_bucket": "test-bucket",
-                "s3_paths": ["test/path/data.csv"],
-                "s3_region": "us-east-1",
-                "replication_method": "FULL_TABLE",
-                "rows_uploaded": 100,
-            }
-        }
+    @patch("target_redshift.fast_sync.handler.process_operations")
+    def test_process_fast_sync_operations_dispatches(self, mock_process_operations):
+        """Operations are forwarded to handler.process_operations"""
+        operations = {"test_schema-test_table": self._create_fast_sync_s3_info()}
         stream_to_sync = self._create_stream_to_sync()
-        config = {"parallelism": 2, "max_parallelism": 16}
 
-        target_redshift.flush_fast_sync_queue(fast_sync_queue, stream_to_sync, config)
+        target_redshift.process_fast_sync_operations(operations, stream_to_sync, {})
 
-        mock_flush_operations.assert_called_once_with(
-            fast_sync_queue, stream_to_sync, 2, 16, False
+        mock_process_operations.assert_called_once_with(
+            operations, stream_to_sync, False
         )
-        assert fast_sync_queue == {}
 
-    @patch("target_redshift.fast_sync.handler.flush_operations")
-    def test_flush_fast_sync_queue_default_parallelism(self, mock_flush_operations):
-        """Test flush_fast_sync_queue with default parallelism values"""
-        fast_sync_queue = {
-            "test_schema-test_table": {
-                "s3_bucket": "test-bucket",
-                "s3_paths": ["test/path/data.csv"],
-                "s3_region": "us-east-1",
-                "replication_method": "FULL_TABLE",
-            }
-        }
+    @patch("target_redshift.fast_sync.handler.process_operations")
+    def test_process_fast_sync_operations_forwards_iceberg_enabled(
+        self, mock_process_operations
+    ):
+        """iceberg_enabled from config is forwarded to handler.process_operations"""
+        operations = {"test_schema-test_table": self._create_fast_sync_s3_info()}
         stream_to_sync = self._create_stream_to_sync()
-        config = {}
 
-        target_redshift.flush_fast_sync_queue(fast_sync_queue, stream_to_sync, config)
-
-        mock_flush_operations.assert_called_once_with(
-            fast_sync_queue, stream_to_sync, 0, 16, False
+        target_redshift.process_fast_sync_operations(
+            operations, stream_to_sync, {"iceberg_enabled": True}
         )
-        assert fast_sync_queue == {}
+
+        mock_process_operations.assert_called_once_with(
+            operations, stream_to_sync, True
+        )
 
     def test_cleanup_fast_sync_s3_info_from_state(self):
         """Test cleanup_fast_sync_s3_info_from_state removes fast_sync_s3_info from bookmarks"""
@@ -378,11 +356,11 @@ class TestTargetRedshift:
         # Should not raise any exception - function handles missing bookmarks gracefully
         fast_sync_handler.cleanup_fast_sync_s3_info_from_state(state, processed_streams)
 
-    @patch("target_redshift.fast_sync.handler.flush_operations")
+    @patch("target_redshift.fast_sync.handler.process_operations")
     @patch("target_redshift.flush_streams")
     @patch("target_redshift.DbSync")
     def test_persist_lines_with_state_containing_fast_sync_info(
-        self, db_sync_mock, flush_streams_mock, mock_flush_operations
+        self, db_sync_mock, flush_streams_mock, mock_process_operations
     ):
         """Test persist_lines processes STATE messages with fast_sync_s3_info"""
         self.config["batch_size_rows"] = 100000
@@ -440,6 +418,73 @@ class TestTargetRedshift:
 
         target_redshift.persist_lines(self.config, lines)
 
-        # Verify fast_sync operations were flushed at the end
-        mock_flush_operations.assert_called_once()
+        # Verify fast_sync operations were processed
+        mock_process_operations.assert_called_once()
         flush_streams_mock.assert_called_once()
+
+    @patch("target_redshift.fast_sync.handler.process_operations")
+    @patch("target_redshift.DbSync")
+    def test_persist_lines_processes_every_fast_sync_state(
+        self, db_sync_mock, mock_process_operations
+    ):
+        """Regression: each STATE with fast_sync_s3_info must be processed
+        on arrival, not just the last one for a given stream.
+
+        The tap's in-loop windowed initial load emits one STATE per window,
+        each carrying a different ``fast_sync_s3_info`` for the SAME
+        stream_id. Earlier this target queued operations in a stream_id-keyed
+        dict and flushed only once at end-of-input - every STATE after the
+        first silently overwrote the prior queued entry, so all but the last
+        window's S3 file was dropped.
+        """
+        instance = db_sync_mock.return_value
+        instance.create_schema_if_not_exists.return_value = None
+        instance.sync_table.return_value = None
+
+        s3_paths_emitted = [
+            "test/path/window_1.csv",
+            "test/path/window_2.csv",
+            "test/path/window_3.csv",
+        ]
+        lines = [
+            json.dumps(
+                {
+                    "type": "SCHEMA",
+                    "stream": "test_schema-test_table",
+                    "schema": {"properties": {"id": {"type": ["null", "integer"]}}},
+                    "key_properties": ["id"],
+                }
+            )
+            + "\n",
+        ] + [
+            json.dumps(
+                {
+                    "type": "STATE",
+                    "value": {
+                        "bookmarks": {
+                            "test_schema-test_table": {
+                                "fast_sync_s3_info": self._create_fast_sync_s3_info(
+                                    s3_paths=[path]
+                                )
+                            }
+                        }
+                    },
+                }
+            )
+            + "\n"
+            for path in s3_paths_emitted
+        ]
+
+        target_redshift.persist_lines(self.config, lines)
+
+        assert mock_process_operations.call_count == len(s3_paths_emitted)
+
+        # extract_operations_from_state returns a fresh dict per STATE, so
+        # call_args_list holds three distinct dicts - safe to inspect.
+        flushed_paths = [
+            path
+            for call in mock_process_operations.call_args_list
+            for op in call.args[0].values()
+            for path in op["s3_paths"]
+        ]
+        assert sorted(flushed_paths) == sorted(s3_paths_emitted)


### PR DESCRIPTION
https://kaligo.atlassian.net/browse/DATA-33249

## Summary

- **Adapt to [Kaligo/pipelinewise-tap-postgres#25](https://github.com/Kaligo/pipelinewise-tap-postgres/pull/25) (windowed initial load).** The tap now emits one STATE per window for the same stream. Previously this target collected operations into a `stream_id`-keyed dict and flushed only at end-of-input - so each new window's `fast_sync_s3_info` overwrote the prior queued entry and all but the last window's S3 file was silently dropped. Operations are now processed on STATE arrival, which also matches Singer semantics (STATE = checkpoint, target commits before tap advances).
- **Drop `joblib.parallel_backend` from fast_sync.** With one stream per Meltano run and one operation per STATE, the per-call queue holds at most one entry. The parallelism layer added complexity and overhead without benefit; replaced with a plain serial loop.

## Test plan

- [ ] Existing unit tests pass (81/81)
- [ ] New regression test (`test_persist_lines_processes_every_fast_sync_state`) sends three back-to-back STATE messages with distinct `fast_sync_s3_info` for the same stream and verifies all three are processed (the prior implementation collapsed them to one)
- [ ] Validate end-to-end against tap PR #25 in staging: confirm every window's parquet lands in Redshift, not just the last

🤖 Generated with [Claude Code](https://claude.com/claude-code)